### PR TITLE
Main App

### DIFF
--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -36,7 +36,7 @@
 			**/model/Product.java,
 			**/model/Stock.java,
 			**/utils/GUITestExtension.java,
-			**/app/swing/App.java
+			**/app/**/*
 		</sonar.coverage.exclusions>
 
 		<sonar.junit.reportPaths>
@@ -243,7 +243,7 @@
 							<exclude>**/model/Product.class</exclude>
 							<exclude>**/model/Stock.class</exclude>
 							<exclude>**/utils/GUITestExtension.class</exclude>
-							<exclude>**/app/swing/App.class</exclude>
+							<exclude>**/app/**/*</exclude>
 						</excludes>
 					</configuration>
 					<executions>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -29,6 +29,8 @@
 		<testcontainers.version>1.16.3</testcontainers.version>
 		<mysql.version>8.0.28</mysql.version>
 		<hibernate.version>5.3.23.Final</hibernate.version>
+		
+		<picocli.version>4.6.2</picocli.version>
 
 		<sonar.coverage.exclusions>
 			**/model/Product.java,
@@ -175,6 +177,12 @@
 			<groupId>org.hibernate</groupId>
 			<artifactId>hibernate-core</artifactId>
 			<version>${hibernate.version}</version>
+		</dependency>
+		<!-- https://mvnrepository.com/artifact/info.picocli/picocli -->
+		<dependency>
+			<groupId>info.picocli</groupId>
+			<artifactId>picocli</artifactId>
+			<version>${picocli.version}</version>
 		</dependency>
 
 	</dependencies>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -35,7 +35,8 @@
 		<sonar.coverage.exclusions>
 			**/model/Product.java,
 			**/model/Stock.java,
-			**/utils/GUITestExtension.java
+			**/utils/GUITestExtension.java,
+			**/app/swing/App.java
 		</sonar.coverage.exclusions>
 
 		<sonar.junit.reportPaths>
@@ -242,6 +243,7 @@
 							<exclude>**/model/Product.class</exclude>
 							<exclude>**/model/Stock.class</exclude>
 							<exclude>**/utils/GUITestExtension.class</exclude>
+							<exclude>**/app/swing/App.class</exclude>
 						</excludes>
 					</configuration>
 					<executions>

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/DBInitializer.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/DBInitializer.java
@@ -1,0 +1,12 @@
+package com.github.raffaelliscandiffio.app.dbinit;
+
+import com.github.raffaelliscandiffio.controller.PurchaseBroker;
+
+public interface DBInitializer {
+	
+	public void startDbConnection();
+
+	public void closeDbConnection();
+
+	public PurchaseBroker getBroker();
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/MongoInitializer.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/MongoInitializer.java
@@ -1,0 +1,50 @@
+package com.github.raffaelliscandiffio.app.dbinit;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.github.raffaelliscandiffio.controller.PurchaseBroker;
+import com.github.raffaelliscandiffio.repository.mongo.ProductMongoRepository;
+import com.github.raffaelliscandiffio.repository.mongo.StockMongoRepository;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+
+public class MongoInitializer implements DBInitializer {
+
+	private PurchaseBroker broker;
+	private MongoClient client;
+	private String dbName = "totem";
+	
+	private final Logger logger = LogManager.getLogger(MongoInitializer.class);
+	
+	@Override
+	public void startDbConnection() {
+
+		try {
+			client = new MongoClient(new ServerAddress("localhost", 27017));
+			// reset db at each start of the application
+			client.getDatabase(dbName).drop();
+
+			ProductMongoRepository productMongoRepository = new ProductMongoRepository(client, dbName, "product");
+			StockMongoRepository stockMongoRepository = new StockMongoRepository(client, dbName, "stock");
+
+			broker = new PurchaseBroker(productMongoRepository, stockMongoRepository);
+
+		} catch (Exception e) {
+			logger.log(Level.ERROR, "Mongo Exception", e);
+		}
+	}
+
+	@Override
+	public void closeDbConnection() {
+		logger.log(Level.INFO, "Close mongo client");
+		client.close();
+	}
+
+	@Override
+	public PurchaseBroker getBroker() {
+		return broker;
+	}
+
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/MySQLInitializer.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/dbinit/MySQLInitializer.java
@@ -1,0 +1,50 @@
+package com.github.raffaelliscandiffio.app.dbinit;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.github.raffaelliscandiffio.controller.PurchaseBroker;
+import com.github.raffaelliscandiffio.repository.mysql.ProductMySQLRepository;
+import com.github.raffaelliscandiffio.repository.mysql.StockMySQLRepository;
+
+public class MySQLInitializer implements DBInitializer {
+	private EntityManagerFactory emf;
+	private EntityManager entityManager;
+	private PurchaseBroker broker;
+	
+	private final Logger logger = LogManager.getLogger(MySQLInitializer.class);
+	
+	@Override
+	public void startDbConnection() {
+		try {
+			emf = Persistence.createEntityManagerFactory("mysql-production");
+			entityManager = emf.createEntityManager();
+
+			ProductMySQLRepository productMySQLRepository = new ProductMySQLRepository(entityManager);
+			StockMySQLRepository stockMySQLRepository = new StockMySQLRepository(entityManager);
+			broker = new PurchaseBroker(productMySQLRepository, stockMySQLRepository);
+
+		} catch (Exception e) {
+			logger.log(Level.ERROR, "MySQL Exception", e);
+		}
+	}
+	
+	@Override
+	public void closeDbConnection() {
+		if (emf != null) {
+			entityManager.close();
+			emf.close();
+			logger.log(Level.INFO, "Close entity manager and factory");
+		}
+	}
+	
+	@Override
+	public PurchaseBroker getBroker() {
+		return broker;
+	}
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -22,49 +22,57 @@ import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
 
 @Command(mixinStandardHelpOptions = true)
-public class App implements Callable<Void>{
-	
+public class App implements Callable<Void> {
+
 	private static final Logger LOGGER = LogManager.getLogger(App.class);
-	
+
 	@Option(names = { "--database" }, description = "Either 'mongo' or 'mysql'")
 	private String databaseType = "mysql";
-	
-	
+
 	public static void main(String[] args) {
 		new CommandLine(new App()).execute(args);
 	}
-	
+
 	@Override
 	public Void call() throws Exception {
-      
+
 		EventQueue.invokeLater(() -> {
-			if(databaseType.equals("mysql")) {
+
+			switch (databaseType) {
+			case "mysql":
 				try {
-					
+
 					EntityManagerFactory emf;
 					EntityManager entityManager;
-				
-			        emf = Persistence.createEntityManagerFactory("mysql-production");
-			        entityManager = emf.createEntityManager();
-					
+
+					emf = Persistence.createEntityManagerFactory("mysql-production");
+					entityManager = emf.createEntityManager();
+
 					ProductMySQLRepository productMySQLRepository = new ProductMySQLRepository(entityManager);
 					StockMySQLRepository stockMySQLRepository = new StockMySQLRepository(entityManager);
-					
-					TotemSwingView totemView = new TotemSwingView(); 
+
+					TotemSwingView totemView = new TotemSwingView();
 					PurchaseBroker broker = new PurchaseBroker(productMySQLRepository, stockMySQLRepository);
 					// fill the database each time
 					broker.saveNewProductInStock(1, "Pasta", 2.5, 300);
 					broker.saveNewProductInStock(2, "Pizza", 5.7, 700);
 					broker.saveNewProductInStock(3, "Broccoli", 2.3, 1000);
 					broker.saveNewProductInStock(4, "Tangerine", 1.1, 2000);
-					
-					TotemController totemController = new TotemController(broker, totemView, null); 
-					totemView.setTotemController(totemController); 
+
+					TotemController totemController = new TotemController(broker, totemView, null);
+					totemView.setTotemController(totemController);
 					totemView.setVisible(true);
-					
+
 				} catch (Exception e) {
 					LOGGER.log(Level.ERROR, "Exception", e);
 				}
+				break;
+			case "mongo":
+
+				break;
+
+			default:
+				LOGGER.log(Level.ERROR, "--database must be either 'mysql' or 'mongo'");
 			}
 		});
 		return null;

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -1,0 +1,70 @@
+package com.github.raffaelliscandiffio.app.swing;
+
+import java.awt.EventQueue;
+import java.util.concurrent.Callable;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import com.github.raffaelliscandiffio.controller.PurchaseBroker;
+import com.github.raffaelliscandiffio.controller.TotemController;
+import com.github.raffaelliscandiffio.repository.mysql.ProductMySQLRepository;
+import com.github.raffaelliscandiffio.repository.mysql.StockMySQLRepository;
+import com.github.raffaelliscandiffio.view.swing.TotemSwingView;
+
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Option;
+
+@Command(mixinStandardHelpOptions = true)
+public class App implements Callable<Void>{
+
+	
+	@Option(names = { "--database" }, description = "Either 'mongo' or 'mysql'")
+	private String databaseType = "mysql";
+	
+	
+	public static void main(String[] args) {
+		new CommandLine(new App()).execute(args);
+	}
+	
+	@Override
+	public Void call() throws Exception {
+      
+		EventQueue.invokeLater(() -> {
+			
+			if(databaseType.equals("mysql")) {
+				try {
+					
+					EntityManagerFactory emf;
+					EntityManager entityManager;
+				
+			        emf = Persistence.createEntityManagerFactory("mysql-production");
+			        entityManager = emf.createEntityManager();
+					
+					ProductMySQLRepository productMySQLRepository = new ProductMySQLRepository(entityManager);
+					StockMySQLRepository stockMySQLRepository = new StockMySQLRepository(entityManager);
+					
+					TotemSwingView totemView = new TotemSwingView(); 
+					PurchaseBroker broker = new PurchaseBroker(productMySQLRepository, stockMySQLRepository);
+					// fill the database each time
+					broker.saveNewProductInStock(1, "Pasta", 2.5, 300);
+					broker.saveNewProductInStock(2, "Pizza", 5.7, 700);
+					broker.saveNewProductInStock(3, "Broccoli", 2.3, 1000);
+					broker.saveNewProductInStock(4, "Tangerine", 1.1, 2000);
+					TotemController totemController = new TotemController(broker, totemView, null); 
+					totemView.setTotemController(totemController); 
+					totemView.setVisible(true);
+					
+				} catch (Exception e) {
+					e.printStackTrace();
+				}
+			}
+		});
+		return null;
+	}
+
+}
+
+

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -3,6 +3,7 @@ package com.github.raffaelliscandiffio.app.swing;
 import java.awt.EventQueue;
 import java.io.BufferedReader;
 import java.io.FileReader;
+import java.io.IOException;
 import java.util.concurrent.Callable;
 
 import javax.persistence.EntityManager;
@@ -105,12 +106,13 @@ public class App implements Callable<Void> {
 		
 		try (BufferedReader br = new BufferedReader(new FileReader("src/main/resources/initDB.csv"))) {
 		    String line;
+		    br.readLine();  // skip first line
 		    while ((line = br.readLine()) != null) {
 		        String[] values = line.split(",");
 		        insertProduct(broker, values);
 		    }
-		}  catch (Exception e) {
-			LOGGER.log(Level.ERROR, "Exception loading file", e);
+		}  catch (IOException e) {
+			LOGGER.log(Level.ERROR, "Exception reading file", e);
 		}
 	}
 

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -1,9 +1,17 @@
 package com.github.raffaelliscandiffio.app.swing;
 
 import java.awt.EventQueue;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.Callable;
+import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -94,27 +102,31 @@ public class App implements Callable<Void> {
 			} catch (Exception e) {
 				LOGGER.log(Level.ERROR, "Exception", e);
 			}
-
 		});
 		return null;
 	}
 
 	private void fillDB(PurchaseBroker broker) {
 		// fill the database each time
-
-		List<String[]> dataLines = new ArrayList<>();
-		dataLines.add(new String[] { "1", "Pasta", "2.5", "300" });
-		dataLines.add(new String[] { "2", "Pizza", "5.7", "700" });
-		dataLines.add(new String[] { "3", "Broccoli", "1.5", "1000" });
-		dataLines.add(new String[] { "4", "Tangerine", "1.1", "2000" });
-
-		dataLines.stream().forEach(el -> {
-			try {
-				broker.saveNewProductInStock(Long.parseLong(el[0]), el[1], Double.parseDouble(el[2]),
-						Integer.parseInt(el[3]));
-			} catch (IllegalArgumentException ie) {
-				LOGGER.log(Level.ERROR, "Illegal argument exception", ie);
-			}
-		});
+		
+		try (BufferedReader br = new BufferedReader(new FileReader("src/main/resources/initDB.csv"))) {
+		    String line;
+		    while ((line = br.readLine()) != null) {
+		        String[] values = line.split(",");
+		        insertProduct(broker, values);
+		    }
+		}  catch (Exception e) {
+			LOGGER.log(Level.ERROR, "Exception loading file", e);
+		}
 	}
+
+	private void insertProduct(PurchaseBroker broker, String[] values) {
+		try {
+			broker.saveNewProductInStock(Long.parseLong(values[0]), values[1], Double.parseDouble(values[2]),
+					Integer.parseInt(values[3]));
+		}catch (IllegalArgumentException ie) {
+			LOGGER.log(Level.ERROR, "Illegal argument exception", ie);
+		}
+	}
+
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -13,9 +13,13 @@ import org.apache.logging.log4j.Logger;
 
 import com.github.raffaelliscandiffio.controller.PurchaseBroker;
 import com.github.raffaelliscandiffio.controller.TotemController;
+import com.github.raffaelliscandiffio.repository.mongo.ProductMongoRepository;
+import com.github.raffaelliscandiffio.repository.mongo.StockMongoRepository;
 import com.github.raffaelliscandiffio.repository.mysql.ProductMySQLRepository;
 import com.github.raffaelliscandiffio.repository.mysql.StockMySQLRepository;
 import com.github.raffaelliscandiffio.view.swing.TotemSwingView;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
 
 import picocli.CommandLine;
 import picocli.CommandLine.Command;
@@ -68,6 +72,26 @@ public class App implements Callable<Void> {
 				}
 				break;
 			case "mongo":
+
+				String dbName = "totem";
+				MongoClient client = new MongoClient(new ServerAddress("localhost", 27017));
+				// reset db at each start of the application
+				client.getDatabase(dbName).drop();
+				
+				ProductMongoRepository productMongoRepository = new ProductMongoRepository(client, dbName, "product");
+				StockMongoRepository stockMongoRepository = new StockMongoRepository(client, dbName, "stock");
+				TotemSwingView totemView = new TotemSwingView();
+				PurchaseBroker broker = new PurchaseBroker(productMongoRepository, stockMongoRepository);
+
+				// fill the database each time
+				broker.saveNewProductInStock(1, "Pasta", 2.5, 300);
+				broker.saveNewProductInStock(2, "Pizza", 5.7, 700);
+				broker.saveNewProductInStock(3, "Broccoli", 2.3, 1000);
+				broker.saveNewProductInStock(4, "Tangerine", 1.1, 2000);
+
+				TotemController totemController = new TotemController(broker, totemView, null);
+				totemView.setTotemController(totemController);
+				totemView.setVisible(true);
 
 				break;
 

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -7,6 +7,10 @@ import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
 import javax.persistence.Persistence;
 
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 import com.github.raffaelliscandiffio.controller.PurchaseBroker;
 import com.github.raffaelliscandiffio.controller.TotemController;
 import com.github.raffaelliscandiffio.repository.mysql.ProductMySQLRepository;
@@ -19,7 +23,8 @@ import picocli.CommandLine.Option;
 
 @Command(mixinStandardHelpOptions = true)
 public class App implements Callable<Void>{
-
+	
+	private static final Logger LOGGER = LogManager.getLogger(App.class);
 	
 	@Option(names = { "--database" }, description = "Either 'mongo' or 'mysql'")
 	private String databaseType = "mysql";
@@ -33,7 +38,6 @@ public class App implements Callable<Void>{
 	public Void call() throws Exception {
       
 		EventQueue.invokeLater(() -> {
-			
 			if(databaseType.equals("mysql")) {
 				try {
 					
@@ -53,18 +57,16 @@ public class App implements Callable<Void>{
 					broker.saveNewProductInStock(2, "Pizza", 5.7, 700);
 					broker.saveNewProductInStock(3, "Broccoli", 2.3, 1000);
 					broker.saveNewProductInStock(4, "Tangerine", 1.1, 2000);
+					
 					TotemController totemController = new TotemController(broker, totemView, null); 
 					totemView.setTotemController(totemController); 
 					totemView.setVisible(true);
 					
 				} catch (Exception e) {
-					e.printStackTrace();
+					LOGGER.log(Level.ERROR, "Exception", e);
 				}
 			}
 		});
 		return null;
 	}
-
 }
-
-

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -49,13 +49,12 @@ public class App implements Callable<Void> {
 			switch (databaseType) {
 			case "mysql":
 				EntityManagerFactory emf;
-				
+
 				EntityManager entityManager;
 
 				try {
 					emf = Persistence.createEntityManagerFactory("mysql-production");
 					entityManager = emf.createEntityManager();
-					
 
 					ProductMySQLRepository productMySQLRepository = new ProductMySQLRepository(entityManager);
 					StockMySQLRepository stockMySQLRepository = new StockMySQLRepository(entityManager);
@@ -104,14 +103,12 @@ public class App implements Callable<Void> {
 	private void fillDB(PurchaseBroker broker) {
 		// fill the database each time
 		
-		try (BufferedReader br = new BufferedReader(new FileReader("src/main/resources/initDB.csv"))) {
-		    String line;
-		    br.readLine();  // skip first line
-		    while ((line = br.readLine()) != null) {
-		        String[] values = line.split(",");
-		        insertProduct(broker, values);
-		    }
-		}  catch (IOException e) {
+		try(BufferedReader br = new BufferedReader(new FileReader("src/main/resources/initDB.csv"))){
+			br.lines().skip(1).forEach(line->{
+				String[] values = line.split(",");
+				insertProduct(broker, values);
+			});
+		}catch(IOException e) {
 			LOGGER.log(Level.ERROR, "Exception reading file", e);
 		}
 	}
@@ -120,7 +117,7 @@ public class App implements Callable<Void> {
 		try {
 			broker.saveNewProductInStock(Long.parseLong(values[0]), values[1], Double.parseDouble(values[2]),
 					Integer.parseInt(values[3]));
-		}catch (IllegalArgumentException ie) {
+		} catch (IllegalArgumentException ie) {
 			LOGGER.log(Level.ERROR, "Illegal argument exception", ie);
 		}
 	}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/app/swing/App.java
@@ -2,16 +2,8 @@ package com.github.raffaelliscandiffio.app.swing;
 
 import java.awt.EventQueue;
 import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileNotFoundException;
 import java.io.FileReader;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.concurrent.Callable;
-import java.util.stream.Stream;
 
 import javax.persistence.EntityManager;
 import javax.persistence.EntityManagerFactory;
@@ -56,11 +48,13 @@ public class App implements Callable<Void> {
 			switch (databaseType) {
 			case "mysql":
 				EntityManagerFactory emf;
+				
 				EntityManager entityManager;
 
 				try {
 					emf = Persistence.createEntityManagerFactory("mysql-production");
 					entityManager = emf.createEntityManager();
+					
 
 					ProductMySQLRepository productMySQLRepository = new ProductMySQLRepository(entityManager);
 					StockMySQLRepository stockMySQLRepository = new StockMySQLRepository(entityManager);
@@ -128,5 +122,4 @@ public class App implements Callable<Void> {
 			LOGGER.log(Level.ERROR, "Illegal argument exception", ie);
 		}
 	}
-
 }

--- a/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/persistence.xml
+++ b/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+	version="2.0">
+
+	<persistence-unit name="mysql-production"
+		transaction-type="RESOURCE_LOCAL">
+		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
+		<mapping-file>/META-INF/Product.hbm.xml</mapping-file>
+		<mapping-file>/META-INF/Stock.hbm.xml</mapping-file>
+		<class>com.github.raffaelliscandiffio.model.Product</class>
+		<class>com.github.raffaelliscandiffio.model.Stock</class>
+		<exclude-unlisted-classes>true</exclude-unlisted-classes>
+		<properties>
+		
+		<property name="javax.persistence.jdbc.driver" value="com.mysql.cj.jdbc.Driver"/>
+            <property name="hibernate.show_sql" value="false"/>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.MySQL8Dialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="javax.persistence.jdbc.url" value="jdbc:mysql://localhost:3306/totem"/>
+            <property name="javax.persistence.jdbc.user" value="root"/>
+		</properties>
+	</persistence-unit>
+</persistence>

--- a/raffaelliscandiffio.shop-totem/src/main/resources/initDB.csv
+++ b/raffaelliscandiffio.shop-totem/src/main/resources/initDB.csv
@@ -1,0 +1,5 @@
+id,Name,Price,Quantity
+1,Pasta,2.5,300
+2,Pizza,5.7,700
+3,Broccoli,1.5,1000
+4,Tangerine,1.1,2000


### PR DESCRIPTION
Adds a way to launch the application for manual testing introducing the `main` method. This is done by adding the following classes:
- `App` takes the command line option `--database` accepting either `"mongo"` or `"mysql"` (default). Launches the application connecting to the desired database creating a `MongoInitializer` or `MySQLInitializer` object. Each time the app is started, it empties the database and fills it with data contained in the `src/main/resources/initDB.csv` file in order to reset the amount of products available.
- `DBInitializer` interface contains the methods for starting a db connection.
- `MongoInitializer` implements `DBInitializer` allowing the creation and closure of a connection to the Mongo Client. 
- `MySQLInitializer` implements `DBInitializer` allowing the creation and closure of a connection to a MySQL database through the JPA EntityManager. 

**Note:** 
The launch of the application is dependent on the presence of _mysql_ or _mongo_ databases. These can be started in a docker container respectively with:

- _MySQL:_

```bash
docker run -d -p 3306:3306 -e MYSQL_DATABASE="totem" -e MYSQL_ROOT_PASSWORD="" -e MYSQL_ALLOW_EMPTY_PASSWORD="yes" mysql:8.0.28
```
- _Mongo:_

```bash
docker run -d -p 27017:27017 mongo:5.0.6
```
