### PR TITLE
Define OrderItem as Entity, add reference checks in mongo repositories

### DIFF
--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -29,7 +29,7 @@
 		<testcontainers.version>1.16.3</testcontainers.version>
 		<mysql.version>8.0.28</mysql.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
-		
+
 		<picocli.version>4.6.2</picocli.version>
 
 		<sonar.coverage.exclusions>
@@ -37,7 +37,7 @@
 			**/model/Stock.java,
 			**/model/OrderItem.java,
 			**/model/Order.java,
-			**/model/OrderStatus.java,	
+			**/model/OrderStatus.java,
 			**/utils/GUITestExtension.java,
 			**/controller/TotemController.java,
 			**/app/**/*
@@ -78,7 +78,7 @@
 		<sonar.issue.ignore.multicriteria.e4.resourceKey>
 			**/swing/TotemSwingView*
 		</sonar.issue.ignore.multicriteria.e4.resourceKey>
-		
+
 		<!-- disable rule on cognitive complexity -->
 		<sonar.issue.ignore.multicriteria.e5.ruleKey>
 			java:S3776
@@ -228,30 +228,33 @@
 							<version>0.14</version>
 						</dependency>
 					</dependencies>
-         <configuration>
+					<configuration>
 
-            <targetClasses>
-               <param>*repository.mysql.OrderMySqlRepository*</param>
-               <param>*repository.mysql.StockMySqlRepository*</param>
-               <param>*repository.mysql.ProductMySqlRepository*</param>
-               <param>*transaction.mysql.TransactionManagerMySql*</param>
-             
-               <param>*repository.mongo.OrderMongoRepository*</param>
-               <param>*repository.mongo.StockMongoRepository*</param>
-               <param>*repository.mongo.ProductMongoRepository*</param>
-               <param>*transaction.mongo.TransactionManagerMongo*</param>
-            </targetClasses>
-            <targetTests>
-  				<param>*repository.mysql*</param>
-                <param>*repository.mongo*</param>
-              <param>*transaction.mysql*</param>
-              <param>*transaction.mongo*</param>            
-              </targetTests>
-            <mutators>
-   				STRONGER
-            </mutators>
-            <mutationThreshold>100</mutationThreshold>
-          </configuration>
+						<targetClasses>
+							<param>*repository.mysql.OrderMySqlRepository*</param>
+							<param>*repository.mysql.OrderItemMySqlRepository*</param>
+							<param>*repository.mysql.StockMySqlRepository*</param>
+							<param>*repository.mysql.ProductMySqlRepository*</param>
+
+							<param>*repository.mongo.OrderMongoRepository*</param>
+							<param>*repository.mongo.OrderItemMongoRepository*</param>						
+							<param>*repository.mongo.StockMongoRepository*</param>
+							<param>*repository.mongo.ProductMongoRepository*</param>
+
+							<param>*transaction.mysql.TransactionManagerMySql*</param>
+							<param>*transaction.mongo.TransactionManagerMongo*</param>
+						</targetClasses>
+						<targetTests>
+							<param>*repository.mysql*</param>
+							<param>*repository.mongo*</param>
+							<param>*transaction.mysql*</param>
+							<param>*transaction.mongo*</param>
+						</targetTests>
+						<mutators>
+							STRONGER
+						</mutators>
+						<mutationThreshold>100</mutationThreshold>
+					</configuration>
 				</plugin>
 
 				<plugin>

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
@@ -169,6 +169,32 @@ class OrderItemMongoRepositoryIT {
 		session.commitTransaction();
 	}
 
+	@Test
+	@DisplayName("Remove OrderItem from the collection by id with 'delete'")
+	void testDelete() {
+		String idToRemove = getNewStringId();
+		OrderItem orderItem = newOrderItemWithId(getNewStringId(), product_1, order_1, QUANTITY_1);
+		OrderItem itemToRemove = newOrderItemWithId(idToRemove, product_2, order_2, QUANTITY_2);
+		saveTestOrderItemToDatabase(orderItem);
+		saveTestOrderItemToDatabase(itemToRemove);
+		orderItemRepository.delete(idToRemove);
+		assertThat(readAllOrderItemFromDatabase()).containsExactly(orderItem);
+	}
+
+	@Test
+	@DisplayName("Method 'delete' should be bound to the repository session")
+	void testDeleteShouldBeBoundToTheRepositorySession() {
+		String idToRemove = getNewStringId();
+		OrderItem orderItem = newOrderItemWithId(getNewStringId(), product_1, order_1, QUANTITY_1);
+		OrderItem itemToRemove = newOrderItemWithId(idToRemove, product_2, order_2, QUANTITY_2);
+		session.startTransaction();
+		saveTestOrderItemToDatabaseWithSession(session, orderItem);
+		saveTestOrderItemToDatabaseWithSession(session, itemToRemove);
+		orderItemRepository.delete(idToRemove);
+		session.commitTransaction();
+		assertThat(readAllOrderItemFromDatabase()).containsExactly(orderItem);
+	}
+
 	// Private utility methods
 
 	private String getNewStringId() {

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
@@ -1,0 +1,198 @@
+package com.github.raffaelliscandiffio.repository.mongo;
+
+import static com.mongodb.client.model.Filters.eq;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+
+import org.assertj.core.api.SoftAssertions;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.github.raffaelliscandiffio.model.Order;
+import com.github.raffaelliscandiffio.model.OrderItem;
+import com.github.raffaelliscandiffio.model.OrderStatus;
+import com.github.raffaelliscandiffio.model.Product;
+import com.mongodb.MongoClient;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
+@Testcontainers(disabledWithoutDocker = true)
+class OrderItemMongoRepositoryIT {
+
+	@Container
+	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");
+	private static final String DATABASE_NAME = "totem";
+	private static final String PRODUCT_COLLECTION_NAME = "product";
+	private static final String ORDER_COLLECTION_NAME = "order";
+	private static final String ORDERITEM_COLLECTION_NAME = "orderItem";
+	private static final int QUANTITY_1 = 1;
+
+	private MongoClient client;
+	private ClientSession session;
+	private OrderItemMongoRepository orderItemRepository;
+	private MongoCollection<Document> productCollection;
+	private MongoCollection<Document> orderCollection;
+	private MongoCollection<Document> orderItemCollection;
+
+	private Product product_1;
+	private Order order_1;
+
+	@BeforeEach
+	public void setup() {
+		client = new MongoClient(new ServerAddress(mongo.getContainerIpAddress(), mongo.getFirstMappedPort()));
+		MongoDatabase database = client.getDatabase(DATABASE_NAME);
+		database.drop();
+		productCollection = database.getCollection(PRODUCT_COLLECTION_NAME);
+		orderCollection = database.getCollection(ORDER_COLLECTION_NAME);
+		orderItemCollection = database.getCollection(ORDERITEM_COLLECTION_NAME);
+		session = client.startSession();
+		orderItemRepository = new OrderItemMongoRepository(client, session, DATABASE_NAME, PRODUCT_COLLECTION_NAME,
+				ORDER_COLLECTION_NAME, ORDERITEM_COLLECTION_NAME);
+		product_1 = saveTestProductToDatabase(new Product("product_1", 1.0));
+		order_1 = saveTestOrderToDatabase(new Order(OrderStatus.OPEN));
+
+	}
+
+	@AfterEach
+	public void tearDown() {
+		session.close();
+		client.close();
+	}
+
+	@Test
+	@DisplayName("Insert OrderItem in database with 'save'")
+	void testSaveOrderItem() {
+		OrderItem orderItem = newOrderItemWithId(getNewStringId(), product_1, order_1, QUANTITY_1);
+		SoftAssertions softly = new SoftAssertions();
+		orderItemRepository.save(orderItem);
+		String assignedId = orderItem.getId();
+		OrderItem expectedResult = newOrderItemWithId(assignedId, product_1, order_1, QUANTITY_1);
+		softly.assertThat(assignedId).isNotNull();
+		softly.assertThatCode(() -> getObjectId(assignedId)).doesNotThrowAnyException();
+		softly.assertThat(readAllOrderItemFromDatabase()).containsExactly(expectedResult);
+		softly.assertAll();
+	}
+
+	@Test
+	@DisplayName("Method 'save' should throw when the referenced product does not exist")
+	void testSaveOrderItemWhenReferencedProductDoesNotExistShouldThrow() {
+		productCollection.drop();
+		OrderItem orderItem = new OrderItem(product_1, order_1, QUANTITY_1);
+		assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
+				.hasMessage(
+						"Reference error, cannot save OrderItem: Product with " + product_1.getId() + " not found.");
+	}
+
+	@Test
+	@DisplayName("Method 'save' should throw when the referenced order does not exist")
+	void testSaveOrderItemWhenReferencedOrderDoesNotExistShouldThrow() {
+		orderCollection.drop();
+		OrderItem orderItem = new OrderItem(product_1, order_1, QUANTITY_1);
+		assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
+				.hasMessage("Reference error, cannot save OrderItem: Order with " + order_1.getId() + " not found.");
+	}
+
+	@Test
+	@DisplayName("In method 'save', the existence check of order should be bound to the repository session")
+	void testSaveOrderItemCheckOnOrderShouldBeBoundToTheRepositorySession() {
+		orderCollection.drop();
+		OrderItem orderItem = newOrderItemWithId(getNewStringId(), product_1, order_1, QUANTITY_1);
+		session.startTransaction();
+		saveTestOrderToDatabaseWithSession(session, order_1);
+		assertThatCode(() -> orderItemRepository.save(orderItem)).doesNotThrowAnyException();
+		session.commitTransaction();
+	}
+
+	@Test
+	@DisplayName("Method 'save' should be bound to the repository session")
+	void testSaveOrderItemShouldBeBoundToTheRepositorySession() {
+		OrderItem orderItem = newOrderItemWithId(getNewStringId(), product_1, order_1, QUANTITY_1);
+		session.startTransaction();
+		orderItemRepository.save(orderItem);
+		assertThat(readAllOrderItemFromDatabase()).isEmpty();
+		session.commitTransaction();
+	}
+
+	// Private utility methods
+
+	private String getNewStringId() {
+		return new ObjectId().toString();
+	}
+
+	private ObjectId getObjectId(String id) {
+		return new ObjectId(id);
+	}
+
+	// --- OrderItem ---
+
+	private OrderItem newOrderItemWithId(String id, Product product, Order order, int quantity) {
+		OrderItem item = new OrderItem(product, order, quantity);
+		item.setId(id);
+		return item;
+	}
+
+	private List<OrderItem> readAllOrderItemFromDatabase() {
+		return StreamSupport.stream(orderItemCollection.find().spliterator(), false).map(orderItemDocument -> {
+			String productId = orderItemDocument.getString("product");
+			String orderId = orderItemDocument.getString("order");
+			Document productDocument = productCollection.find(eq("_id", getObjectId(productId))).first();
+			Product product = new Product(productDocument.getString("name"), productDocument.getDouble("price"));
+			product.setId(productId);
+			Document orderDocument = orderCollection.find(eq("_id", getObjectId(orderId))).first();
+			Order order = new Order(OrderStatus.valueOf(orderDocument.getString("status")));
+			order.setId(orderId);
+			OrderItem orderItem = new OrderItem(product, order, orderItemDocument.getInteger("quantity"));
+			orderItem.setId(orderItemDocument.get("_id").toString());
+			return orderItem;
+		}).collect(Collectors.toList());
+	}
+
+	// --- Product ---
+
+	private Document fromProductToDocument(Product productWithoutId) {
+		return new Document().append("name", productWithoutId.getName()).append("price", productWithoutId.getPrice());
+	}
+
+	private Product saveTestProductToDatabase(Product productWithoutId) {
+		Document doc = fromProductToDocument(productWithoutId);
+		productCollection.insertOne(doc);
+		productWithoutId.setId(doc.get("_id").toString());
+		return productWithoutId;
+	}
+
+	// --- Order ---
+
+	private Document fromOrderToDocument(Order orderWithoutId) {
+		return new Document().append("status", orderWithoutId.getStatus().toString());
+	}
+
+	private Order saveTestOrderToDatabase(Order orderWithoutId) {
+		Document doc = fromOrderToDocument(orderWithoutId);
+		orderCollection.insertOne(doc);
+		orderWithoutId.setId(doc.get("_id").toString());
+		return orderWithoutId;
+	}
+
+	private Order saveTestOrderToDatabaseWithSession(ClientSession session, Order orderWithoutId) {
+		Document doc = fromOrderToDocument(orderWithoutId);
+		orderCollection.insertOne(session, doc);
+		orderWithoutId.setId(doc.get("_id").toString());
+		return orderWithoutId;
+	}
+
+}

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepositoryIT.java
@@ -102,9 +102,12 @@ class OrderItemMongoRepositoryIT {
 	void testSaveOrderItemWhenTheProductReferenceDoesNotExistShouldThrow() {
 		productCollection.drop();
 		OrderItem orderItem = new OrderItem(product_1, order_1, QUANTITY_1);
-		assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
 				.hasMessage(
 						"Reference error, cannot save OrderItem: Product with " + product_1.getId() + " not found.");
+		softly.assertThat(readAllOrderItemFromDatabase()).isEmpty();
+		softly.assertAll();
 	}
 
 	@Test
@@ -112,8 +115,11 @@ class OrderItemMongoRepositoryIT {
 	void testSaveOrderItemWhenTheOrderReferenceDoesNotExistShouldThrow() {
 		orderCollection.drop();
 		OrderItem orderItem = new OrderItem(product_1, order_1, QUANTITY_1);
-		assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
+		SoftAssertions softly = new SoftAssertions();
+		softly.assertThatThrownBy(() -> orderItemRepository.save(orderItem)).isInstanceOf(NoSuchElementException.class)
 				.hasMessage("Reference error, cannot save OrderItem: Order with " + order_1.getId() + " not found.");
+		softly.assertThat(readAllOrderItemFromDatabase()).isEmpty();
+		softly.assertAll();
 	}
 
 	@Test

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryTestcontainersIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryTestcontainersIT.java
@@ -1,15 +1,11 @@
 package com.github.raffaelliscandiffio.repository.mongo;
 
-import static com.mongodb.client.model.Filters.eq;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -25,9 +21,7 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Order;
-import com.github.raffaelliscandiffio.model.OrderItem;
 import com.github.raffaelliscandiffio.model.OrderStatus;
-import com.github.raffaelliscandiffio.model.Product;
 import com.mongodb.MongoClient;
 import com.mongodb.ServerAddress;
 import com.mongodb.client.ClientSession;
@@ -38,22 +32,12 @@ import com.mongodb.client.MongoDatabase;
 class OrderMongoRepositoryTestcontainersIT {
 
 	private static final String DATABASE_NAME = "totem";
-	private static final String PRODUCT_COLLECTION_NAME = "product";
 	private static final String ORDER_COLLECTION_NAME = "order";
-	private static final String PRODUCT_NAME_1 = "product_1";
-	private static final String PRODUCT_NAME_2 = "product_2";
-	private static final double PRICE = 3.0;
-	private static final int QUANTITY = 4;
 
 	private MongoClient client;
 	private ClientSession session;
 	private OrderMongoRepository orderRepository;
-	private MongoCollection<Document> productCollection;
 	private MongoCollection<Document> orderCollection;
-	private Product product_1;
-	private Product product_2;
-	private OrderItem item_1;
-	private OrderItem item_2;
 
 	@Container
 	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");
@@ -61,118 +45,142 @@ class OrderMongoRepositoryTestcontainersIT {
 	@BeforeEach
 	public void setup() {
 		client = new MongoClient(new ServerAddress(mongo.getContainerIpAddress(), mongo.getFirstMappedPort()));
-		session = client.startSession();
-		orderRepository = new OrderMongoRepository(client, session, DATABASE_NAME, PRODUCT_COLLECTION_NAME,
-				ORDER_COLLECTION_NAME);
 		MongoDatabase database = client.getDatabase(DATABASE_NAME);
 		database.drop();
-		productCollection = database.getCollection(PRODUCT_COLLECTION_NAME);
 		orderCollection = database.getCollection(ORDER_COLLECTION_NAME);
-		product_1 = new Product(PRODUCT_NAME_1, PRICE);
-		product_2 = new Product(PRODUCT_NAME_2, PRICE);
-		item_1 = new OrderItem(product_1, QUANTITY);
-		item_2 = new OrderItem(product_2, QUANTITY);
-		addTestProductToDatabase(product_1);
-		addTestProductToDatabase(product_2);
+		session = client.startSession();
+		orderRepository = new OrderMongoRepository(client, session, DATABASE_NAME, ORDER_COLLECTION_NAME);
 	}
 
 	@AfterEach
 	public void tearDown() {
+		session.close();
 		client.close();
 	}
 
 	@Test
 	@DisplayName("Insert Order in database with 'save'")
 	void testSaveOrder() {
-		Order order = new Order(new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN);
+		Order order = new Order(OrderStatus.OPEN);
 		SoftAssertions softly = new SoftAssertions();
-		session.startTransaction();
 		orderRepository.save(order);
 		String assignedId = order.getId();
+		Order expectedResult = newOrderWithId(assignedId, OrderStatus.OPEN);
 		softly.assertThat(assignedId).isNotNull();
 		softly.assertThatCode(() -> new ObjectId(assignedId)).doesNotThrowAnyException();
-		softly.assertThat(readAllOrderFromDatabase()).isEmpty();
-		session.commitTransaction();
-		softly.assertThat(readAllOrderFromDatabase()).containsExactly(
-				createOrderWithId(assignedId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN));
+		softly.assertThat(readAllOrderFromDatabase()).containsExactly(expectedResult);
 		softly.assertAll();
+	}
+
+	@Test
+	@DisplayName("Method 'save' should be bound to the repository session")
+	void testSaveOrderShouldBeBoundToTheRepositorySession() {
+		Order order = new Order(OrderStatus.OPEN);
+		session.startTransaction();
+		orderRepository.save(order);
+		assertThat(readAllOrderFromDatabase()).isEmpty();
+		session.commitTransaction();
 	}
 
 	@Test
 	@DisplayName("Retrieve Order by id with 'findById'")
 	void testFindByIdWhenIdIsFound() {
-		String orderId = getNewStringId();
-		session.startTransaction();
-		addTestOrderToDatabaseWithSession(session, getNewStringId(),
-				new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN);
-		addTestOrderToDatabaseWithSession(session, orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)),
-				OrderStatus.CLOSED);
-		assertThat(orderRepository.findById(orderId)).isEqualTo(
-				createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED));
-		session.commitTransaction();
+		String idToFind = getNewStringId();
+		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		Order order_2 = newOrderWithId(idToFind, OrderStatus.OPEN);
+		Order expectedResult = newOrderWithId(idToFind, OrderStatus.OPEN);
+		saveTestOrderToDatabase(order_1);
+		saveTestOrderToDatabase(order_2);
+		assertThat(orderRepository.findById(idToFind)).isEqualTo(expectedResult);
 	}
 
 	@Test
 	@DisplayName("Method 'findById' should return null when the id is not found")
 	void testFindByIdWhenIdIsNotFoundShouldReturnNull() {
-		String missing_id = getNewStringId();
-		assertThat(orderRepository.findById(missing_id)).isNull();
+		String missingId = getNewStringId();
+		assertThat(orderRepository.findById(missingId)).isNull();
 	}
 
 	@Test
-	@DisplayName("Remove the specified order from the collection with 'delete'")
-	void testDelete() {
-		String orderId = getNewStringId();
-		String removeId = getNewStringId();
-		SoftAssertions softly = new SoftAssertions();
-
-		addTestOrderToDatabase(removeId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN);
-		addTestOrderToDatabase(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED);
+	@DisplayName("Method 'findById' should be bound to the repository session")
+	void testFindByIdShouldBeBoundToTheRepositorySession() {
+		String idToFind = getNewStringId();
+		Order order_1 = newOrderWithId(idToFind, OrderStatus.OPEN);
+		Order expectedResult = newOrderWithId(idToFind, OrderStatus.OPEN);
 		session.startTransaction();
-		orderRepository.delete(
-				createOrderWithId(removeId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN));
-		softly.assertThat(readAllOrderFromDatabase()).containsExactly(
-				createOrderWithId(removeId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN),
-				createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED));
+		saveTestOrderToDatabaseWithSession(session, order_1);
+		assertThat(orderRepository.findById(idToFind)).isEqualTo(expectedResult);
 		session.commitTransaction();
-		softly.assertThat(readAllOrderFromDatabase()).containsExactly(
-				createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED));
-		softly.assertAll();
+	}
+
+	@Test
+	@DisplayName("Remove Order from the collection by id with 'delete'")
+	void testDelete() {
+		String idToRemove = getNewStringId();
+		Order toRemove = newOrderWithId(idToRemove, OrderStatus.OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		saveTestOrderToDatabase(toRemove);
+		saveTestOrderToDatabase(order_1);
+		orderRepository.delete(idToRemove);
+		assertThat(readAllOrderFromDatabase()).containsExactly(order_1);
+	}
+
+	@Test // document the behaviour
+	@DisplayName("Method 'delete' when the order does not exist should not throw exception")
+	void testDeleteWhenOrderDoesNotExistShouldNotThrow() {
+		String idToRemove = getNewStringId();
+		assertThatCode(() -> orderRepository.delete(idToRemove)).doesNotThrowAnyException();
+	}
+
+	@Test
+	@DisplayName("Method 'delete' should be bound to the repository session")
+	void testDeleteShouldBeBoundToTheRepositorySession() {
+		String idToRemove = getNewStringId();
+		Order toRemove = newOrderWithId(idToRemove, OrderStatus.OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		session.startTransaction();
+		saveTestOrderToDatabaseWithSession(session, toRemove);
+		saveTestOrderToDatabaseWithSession(session, order_1);
+		orderRepository.delete(idToRemove);
+		session.commitTransaction();
+		assertThat(readAllOrderFromDatabase()).containsExactly(order_1);
 	}
 
 	@Test
 	@DisplayName("Update Order with 'update'")
 	void updateOrder() {
-		String modifyId = getNewStringId();
-		String orderId = getNewStringId();
-		SoftAssertions softly = new SoftAssertions();
-		Set<OrderItem> items = new LinkedHashSet<OrderItem>(Arrays.asList(item_1));
-		Order toModify = createOrderWithId(modifyId, items, OrderStatus.OPEN);
-		addTestOrderToDatabase(modifyId, items, OrderStatus.OPEN);
-		addTestOrderToDatabase(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED);
-		items.add(item_2);
-		session.startTransaction();
-		orderRepository.update(toModify);
-		softly.assertThat(readAllOrderFromDatabase()).containsExactly(
-				createOrderWithId(modifyId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1)), OrderStatus.OPEN),
-				createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED));
-		session.commitTransaction();
-		softly.assertThat(readAllOrderFromDatabase()).containsExactly(
-				createOrderWithId(modifyId, new LinkedHashSet<OrderItem>(Arrays.asList(item_1, item_2)),
-						OrderStatus.OPEN),
-				createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)), OrderStatus.CLOSED));
-		softly.assertAll();
+		String idToUpdate = getNewStringId();
+		Order toUpdate = newOrderWithId(idToUpdate, OrderStatus.OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		saveTestOrderToDatabase(toUpdate);
+		saveTestOrderToDatabase(order_1);
+		toUpdate.setStatus(OrderStatus.CLOSED);
+		Order expectedResult = newOrderWithId(idToUpdate, OrderStatus.CLOSED);
+		orderRepository.update(toUpdate);
+		assertThat(readAllOrderFromDatabase()).containsExactlyInAnyOrder(order_1, expectedResult);
 	}
 
 	@Test
 	@DisplayName("Update Order when order does not exist should throw")
-	void updateOrderWhenDoesNotExistShouldThrow() {
-		String orderId = getNewStringId();
-		Order unsavedOrder = createOrderWithId(orderId, new LinkedHashSet<OrderItem>(Arrays.asList(item_2)),
-				OrderStatus.CLOSED);
-		assertThatThrownBy(() -> orderRepository.update(unsavedOrder)).isInstanceOf(NoSuchElementException.class)
-				.hasMessage("Order with id " + orderId + " not found.");
-		assertThat(readAllOrderFromDatabase()).isEmpty();
+	void updateOrderWhenItDoesNotExistShouldThrow() {
+		String missingId = getNewStringId();
+		Order missingOrder = newOrderWithId(missingId, OrderStatus.OPEN);
+		assertThatThrownBy(() -> orderRepository.update(missingOrder)).isInstanceOf(NoSuchElementException.class)
+				.hasMessage("Order with id " + missingId + " not found.");
+	}
+
+	@Test
+	@DisplayName("Method 'update' should be bound to the repository session")
+	void updateOrderShouldBeBoundToTheRepositorySession() {
+		String idToUpdate = getNewStringId();
+		Order toUpdate = newOrderWithId(idToUpdate, OrderStatus.OPEN);
+		Order notUpdated = newOrderWithId(idToUpdate, OrderStatus.OPEN);
+		saveTestOrderToDatabase(toUpdate);
+		toUpdate.setStatus(OrderStatus.CLOSED);
+		session.startTransaction();
+		orderRepository.update(toUpdate);
+		assertThat(readAllOrderFromDatabase()).containsExactlyInAnyOrder(notUpdated);
+		session.commitTransaction();
 	}
 
 	// Private utility methods
@@ -181,53 +189,31 @@ class OrderMongoRepositoryTestcontainersIT {
 		return new ObjectId().toString();
 	}
 
-	private List<Order> readAllOrderFromDatabase() {
-		return StreamSupport.stream(orderCollection.find().spliterator(), false).map(orderDocument -> {
-			List<Document> itemDocuments = orderDocument.getList("items", Document.class);
-			LinkedHashSet<OrderItem> items = new LinkedHashSet<>();
-			itemDocuments.forEach(document -> items.add(fromDocumentToOrderItem(document)));
-			Order order = new Order(items, OrderStatus.valueOf(orderDocument.getString("status")));
-			order.setId(orderDocument.get("_id").toString());
-			return order;
-		}).collect(Collectors.toList());
-	}
-
-	private OrderItem fromDocumentToOrderItem(Document document) {
-		Document productDocument = productCollection.find(eq("_id", new ObjectId(document.getString("product"))))
-				.first();
-		Product product = new Product(productDocument.getString("name"), productDocument.getDouble("price"));
-		product.setId(productDocument.get("_id").toString());
-		return new OrderItem(product, document.getInteger("quantity"));
-	}
-
-	private Order createOrderWithId(String id, Set<OrderItem> items, OrderStatus status) {
-		Order order = new Order(items, status);
+	private Order newOrderWithId(String id, OrderStatus status) {
+		Order order = new Order(status);
 		order.setId(id);
 		return order;
 	}
 
-	private void addTestProductToDatabase(Product product) {
-		Document productDocument = new Document().append("name", product.getName()).append("price", product.getPrice());
-		productCollection.insertOne(productDocument);
-		product.setId(productDocument.get("_id").toString());
+	private Document fromOrderToDocument(Order orderWithId) {
+		return new Document().append("_id", new ObjectId(orderWithId.getId())).append("status",
+				orderWithId.getStatus().toString());
 	}
 
-	private void addTestOrderToDatabase(String id, Set<OrderItem> items, OrderStatus status) {
-		orderCollection.insertOne(new Document().append("_id", new ObjectId(id))
-				.append("items", itemsToDocumentList(items)).append("status", status.toString()));
+	private void saveTestOrderToDatabase(Order orderWithId) {
+		orderCollection.insertOne(fromOrderToDocument(orderWithId));
 	}
 
-	private void addTestOrderToDatabaseWithSession(ClientSession session, String id, Set<OrderItem> items,
-			OrderStatus status) {
-		orderCollection.insertOne(session, new Document().append("_id", new ObjectId(id))
-				.append("items", itemsToDocumentList(items)).append("status", status.toString()));
+	private void saveTestOrderToDatabaseWithSession(ClientSession session, Order orderWithId) {
+		orderCollection.insertOne(session, fromOrderToDocument(orderWithId));
 	}
 
-	private List<Document> itemsToDocumentList(Set<OrderItem> items) {
-		List<Document> embeddedItems = new ArrayList<>();
-		items.forEach(item -> embeddedItems.add(
-				new Document().append("product", item.getProduct().getId()).append("quantity", item.getQuantity())));
-		return embeddedItems;
+	private List<Order> readAllOrderFromDatabase() {
+		return StreamSupport.stream(orderCollection.find().spliterator(), false).map(orderDocument -> {
+			Order order = new Order(OrderStatus.valueOf(orderDocument.getString("status")));
+			order.setId(orderDocument.get("_id").toString());
+			return order;
+		}).collect(Collectors.toList());
 	}
 
 }

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryTestcontainersIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryTestcontainersIT.java
@@ -31,6 +31,8 @@ import com.mongodb.client.MongoDatabase;
 @Testcontainers(disabledWithoutDocker = true)
 class OrderMongoRepositoryTestcontainersIT {
 
+	private static final OrderStatus CLOSED = OrderStatus.CLOSED;
+	private static final OrderStatus OPEN = OrderStatus.OPEN;
 	private static final String DATABASE_NAME = "totem";
 	private static final String ORDER_COLLECTION_NAME = "order";
 
@@ -61,11 +63,11 @@ class OrderMongoRepositoryTestcontainersIT {
 	@Test
 	@DisplayName("Insert Order in database with 'save'")
 	void testSaveOrder() {
-		Order order = new Order(OrderStatus.OPEN);
+		Order order = new Order(OPEN);
 		SoftAssertions softly = new SoftAssertions();
 		orderRepository.save(order);
 		String assignedId = order.getId();
-		Order expectedResult = newOrderWithId(assignedId, OrderStatus.OPEN);
+		Order expectedResult = newOrderWithId(assignedId, OPEN);
 		softly.assertThat(assignedId).isNotNull();
 		softly.assertThatCode(() -> new ObjectId(assignedId)).doesNotThrowAnyException();
 		softly.assertThat(readAllOrderFromDatabase()).containsExactly(expectedResult);
@@ -75,7 +77,7 @@ class OrderMongoRepositoryTestcontainersIT {
 	@Test
 	@DisplayName("Method 'save' should be bound to the repository session")
 	void testSaveOrderShouldBeBoundToTheRepositorySession() {
-		Order order = new Order(OrderStatus.OPEN);
+		Order order = new Order(OPEN);
 		session.startTransaction();
 		orderRepository.save(order);
 		assertThat(readAllOrderFromDatabase()).isEmpty();
@@ -86,9 +88,9 @@ class OrderMongoRepositoryTestcontainersIT {
 	@DisplayName("Retrieve Order by id with 'findById'")
 	void testFindByIdWhenIdIsFound() {
 		String idToFind = getNewStringId();
-		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
-		Order order_2 = newOrderWithId(idToFind, OrderStatus.OPEN);
-		Order expectedResult = newOrderWithId(idToFind, OrderStatus.OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OPEN);
+		Order order_2 = newOrderWithId(idToFind, OPEN);
+		Order expectedResult = newOrderWithId(idToFind, OPEN);
 		saveTestOrderToDatabase(order_1);
 		saveTestOrderToDatabase(order_2);
 		assertThat(orderRepository.findById(idToFind)).isEqualTo(expectedResult);
@@ -105,8 +107,8 @@ class OrderMongoRepositoryTestcontainersIT {
 	@DisplayName("Method 'findById' should be bound to the repository session")
 	void testFindByIdShouldBeBoundToTheRepositorySession() {
 		String idToFind = getNewStringId();
-		Order order_1 = newOrderWithId(idToFind, OrderStatus.OPEN);
-		Order expectedResult = newOrderWithId(idToFind, OrderStatus.OPEN);
+		Order order_1 = newOrderWithId(idToFind, OPEN);
+		Order expectedResult = newOrderWithId(idToFind, OPEN);
 		session.startTransaction();
 		saveTestOrderToDatabaseWithSession(session, order_1);
 		assertThat(orderRepository.findById(idToFind)).isEqualTo(expectedResult);
@@ -117,8 +119,8 @@ class OrderMongoRepositoryTestcontainersIT {
 	@DisplayName("Remove Order from the collection by id with 'delete'")
 	void testDelete() {
 		String idToRemove = getNewStringId();
-		Order toRemove = newOrderWithId(idToRemove, OrderStatus.OPEN);
-		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		Order toRemove = newOrderWithId(idToRemove, OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OPEN);
 		saveTestOrderToDatabase(toRemove);
 		saveTestOrderToDatabase(order_1);
 		orderRepository.delete(idToRemove);
@@ -136,8 +138,8 @@ class OrderMongoRepositoryTestcontainersIT {
 	@DisplayName("Method 'delete' should be bound to the repository session")
 	void testDeleteShouldBeBoundToTheRepositorySession() {
 		String idToRemove = getNewStringId();
-		Order toRemove = newOrderWithId(idToRemove, OrderStatus.OPEN);
-		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		Order toRemove = newOrderWithId(idToRemove, OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OPEN);
 		session.startTransaction();
 		saveTestOrderToDatabaseWithSession(session, toRemove);
 		saveTestOrderToDatabaseWithSession(session, order_1);
@@ -148,35 +150,35 @@ class OrderMongoRepositoryTestcontainersIT {
 
 	@Test
 	@DisplayName("Update Order with 'update'")
-	void updateOrder() {
+	void testUpdateOrder() {
 		String idToUpdate = getNewStringId();
-		Order toUpdate = newOrderWithId(idToUpdate, OrderStatus.OPEN);
-		Order order_1 = newOrderWithId(getNewStringId(), OrderStatus.OPEN);
+		Order toUpdate = newOrderWithId(idToUpdate, OPEN);
+		Order order_1 = newOrderWithId(getNewStringId(), OPEN);
 		saveTestOrderToDatabase(toUpdate);
 		saveTestOrderToDatabase(order_1);
-		toUpdate.setStatus(OrderStatus.CLOSED);
-		Order expectedResult = newOrderWithId(idToUpdate, OrderStatus.CLOSED);
+		toUpdate.setStatus(CLOSED);
+		Order expectedResult = newOrderWithId(idToUpdate, CLOSED);
 		orderRepository.update(toUpdate);
 		assertThat(readAllOrderFromDatabase()).containsExactlyInAnyOrder(order_1, expectedResult);
 	}
 
 	@Test
 	@DisplayName("Update Order when order does not exist should throw")
-	void updateOrderWhenItDoesNotExistShouldThrow() {
+	void testUpdateOrderWhenItDoesNotExistShouldThrow() {
 		String missingId = getNewStringId();
-		Order missingOrder = newOrderWithId(missingId, OrderStatus.OPEN);
+		Order missingOrder = newOrderWithId(missingId, OPEN);
 		assertThatThrownBy(() -> orderRepository.update(missingOrder)).isInstanceOf(NoSuchElementException.class)
 				.hasMessage("Order with id " + missingId + " not found.");
 	}
 
 	@Test
 	@DisplayName("Method 'update' should be bound to the repository session")
-	void updateOrderShouldBeBoundToTheRepositorySession() {
+	void testUpdateOrderShouldBeBoundToTheRepositorySession() {
 		String idToUpdate = getNewStringId();
-		Order toUpdate = newOrderWithId(idToUpdate, OrderStatus.OPEN);
-		Order notUpdated = newOrderWithId(idToUpdate, OrderStatus.OPEN);
+		Order toUpdate = newOrderWithId(idToUpdate, OPEN);
+		Order notUpdated = newOrderWithId(idToUpdate, OPEN);
 		saveTestOrderToDatabase(toUpdate);
-		toUpdate.setStatus(OrderStatus.CLOSED);
+		toUpdate.setStatus(CLOSED);
 		session.startTransaction();
 		orderRepository.update(toUpdate);
 		assertThat(readAllOrderFromDatabase()).containsExactlyInAnyOrder(notUpdated);

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepositoryTestcontainersIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepositoryTestcontainersIT.java
@@ -2,8 +2,10 @@ package com.github.raffaelliscandiffio.repository.mongo;
 
 import static com.mongodb.client.model.Filters.eq;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -35,7 +37,8 @@ class StockMongoRepositoryTestcontainersIT {
 	private static final String PRODUCT_NAME_1 = "product_1";
 	private static final String PRODUCT_NAME_2 = "pasta";
 	private static final double PRICE = 3.0;
-	private static final int QUANTITY = 4;
+	private static final int QUANTITY_1 = 1;
+	private static final int QUANTITY_2 = 2;
 
 	@Container
 	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");
@@ -61,123 +64,164 @@ class StockMongoRepositoryTestcontainersIT {
 		stockCollection = database.getCollection(STOCK_COLLECTION_NAME);
 		product_1 = new Product(PRODUCT_NAME_1, PRICE);
 		product_2 = new Product(PRODUCT_NAME_2, PRICE);
-		addTestProductToDatabase(product_1);
-		addTestProductToDatabase(product_2);
+		saveTestProductToDatabase(product_1);
+		saveTestProductToDatabase(product_2);
 	}
 
 	@AfterEach
 	public void tearDown() {
+		session.close();
 		client.close();
 	}
 
 	@Test
 	@DisplayName("Insert Stock in database with 'save'")
-	void testSaveProduct() {
-		Stock stock = new Stock(product_1, QUANTITY);
-		session.startTransaction();
+	void testSaveStock() {
+		Stock stock = new Stock(product_1, QUANTITY_1);
 		stockRepository.save(stock);
 		String assignedId = stock.getId();
+		Stock expectedResult = newStockWithId(assignedId, product_1, QUANTITY_1);
 		SoftAssertions softly = new SoftAssertions();
 		softly.assertThat(assignedId).isNotNull();
 		softly.assertThatCode(() -> new ObjectId(assignedId)).doesNotThrowAnyException();
-		// assert that 'save' is tied to a transaction because it's state can't be read
-		// from outside before the commit
-		softly.assertThat(readAllStocksFromDatabase()).isEmpty();
-		session.commitTransaction();
-		softly.assertThat(readAllStocksFromDatabase())
-				.containsExactly(createTestStockWithId(assignedId, product_1, QUANTITY));
+		softly.assertThat(readAllStockFromDatabase()).containsExactly(expectedResult);
 		softly.assertAll();
+	}
+
+	@Test
+	@DisplayName("Method 'save' should be bound to the repository session")
+	void testSaveStockShouldBeBoundToTheRepositorySession() {
+		Stock stock = new Stock(product_1, QUANTITY_1);
+		session.startTransaction();
+		stockRepository.save(stock);
+		assertThat(readAllStockFromDatabase()).isEmpty();
+		session.commitTransaction();
 	}
 
 	@Test
 	@DisplayName("Retrieve Stock by id with 'findById'")
 	void testFindByIdWhenIdIsFound() {
-		String stockId = new ObjectId().toString();
-		Product sessionProduct = new Product("product_3", 3.0);
-		addTestStockToDatabase(new ObjectId().toString(), product_2, 10);
-		session.startTransaction();
-		addTestProductToDatabaseWithSession(session, sessionProduct);
-		addTestStockToDatabaseWithSession(session, stockId, sessionProduct, QUANTITY);
-		assertThat(stockRepository.findById(stockId))
-				.isEqualTo(createTestStockWithId(stockId, sessionProduct, QUANTITY));
-		session.commitTransaction();
+		String idToFind = getNewStringId();
+		Stock stock_1 = newStockWithId(getNewStringId(), product_1, QUANTITY_1);
+		Stock stock_2 = newStockWithId(idToFind, product_2, QUANTITY_2);
+		Stock expectedResult = newStockWithId(idToFind, product_2, QUANTITY_2);
+		saveTestStockToDatabase(stock_1);
+		saveTestStockToDatabase(stock_2);
+		assertThat(stockRepository.findById(idToFind)).isEqualTo(expectedResult);
 	}
 
 	@Test
 	@DisplayName("Method 'findById' should return null when the id is not found")
 	void testFindByIdWhenIdIsNotFoundShouldReturnNull() {
-		String missing_id = new ObjectId().toString();
-		assertThat(stockRepository.findById(missing_id)).isNull();
+		String missingId = getNewStringId();
+		assertThat(stockRepository.findById(missingId)).isNull();
 	}
 
 	@Test
-	@DisplayName("Update Stock in database with 'update'")
-	void testUpdateProduct() {
-		SoftAssertions softly = new SoftAssertions();
-		String stockId = new ObjectId().toString();
-		String stockId_2 = new ObjectId().toString();
-		addTestStockToDatabase(stockId, product_1, QUANTITY);
-		addTestStockToDatabase(stockId_2, product_2, QUANTITY);
-		int modifiedQuantity = QUANTITY + 5;
+	@DisplayName("Method 'findById' should be bound to the repository session")
+	void testFindByIdShouldBeBoundToTheRepositorySession() {
+		productCollection.drop();
 		session.startTransaction();
-		stockRepository.update(createTestStockWithId(stockId, product_1, modifiedQuantity));
-		softly.assertThat(readAllStocksFromDatabase()).containsExactlyInAnyOrder(
-				createTestStockWithId(stockId, product_1, QUANTITY),
-				createTestStockWithId(stockId_2, product_2, QUANTITY));
+		saveTestProductToDatabaseWithSession(product_1);
+		String idToFind = getNewStringId();
+		Stock stock_1 = newStockWithId(idToFind, product_1, QUANTITY_1);
+		Stock expectedResult = newStockWithId(idToFind, product_1, QUANTITY_1);
+
+		saveTestStockToDatabaseWithSession(session, stock_1);
+		assertThat(stockRepository.findById(idToFind)).isEqualTo(expectedResult);
 		session.commitTransaction();
-		softly.assertThat(readAllStocksFromDatabase()).containsExactlyInAnyOrder(
-				createTestStockWithId(stockId, product_1, modifiedQuantity),
-				createTestStockWithId(stockId_2, product_2, QUANTITY));
-		softly.assertAll();
 	}
 
-	private List<Stock> readAllStocksFromDatabase() {
-		return StreamSupport.stream(stockCollection.find().spliterator(), false).map(stockDocument -> {
-			String productId = stockDocument.getString("product");
-			Document productDocument = productCollection.find(eq("_id", new ObjectId(productId))).first();
-			Product product = new Product(productDocument.getString("name"), productDocument.getDouble("price"));
-			product.setId(productDocument.get("_id").toString());
-			Stock stock = createTestStockWithId(stockDocument.get("_id").toString(), product,
-					stockDocument.getInteger("quantity"));
-			return stock;
-		}).collect(Collectors.toList());
+	@Test
+	@DisplayName("Update Stock with 'update'")
+	void testUpdateStock() {
+		String idToUpdate = getNewStringId();
+		Stock stock_1 = newStockWithId(getNewStringId(), product_1, QUANTITY_1);
+		Stock toUpdate = newStockWithId(idToUpdate, product_2, QUANTITY_2);
+		saveTestStockToDatabase(stock_1);
+		saveTestStockToDatabase(toUpdate);
+		toUpdate.setQuantity(QUANTITY_1);
+		Stock expectedResult = newStockWithId(idToUpdate, product_2, QUANTITY_1);
+		stockRepository.update(toUpdate);
+		assertThat(readAllStockFromDatabase()).containsExactlyInAnyOrder(stock_1, expectedResult);
 	}
 
-	private Stock createTestStockWithId(String id, Product product, int quantity) {
+	@Test
+	@DisplayName("Update Stock when stock does not exist should throw")
+	void testUpdateStockWhenItDoesNotExistShouldThrow() {
+		String missingId = getNewStringId();
+		Stock missingStock = newStockWithId(missingId, product_1, QUANTITY_1);
+		assertThatThrownBy(() -> stockRepository.update(missingStock)).isInstanceOf(NoSuchElementException.class)
+				.hasMessage("Stock with id " + missingId + " not found.");
+	}
+
+	@Test
+	@DisplayName("Method 'update' should be bound to the repository session")
+	void testUpdateStockShouldBeBoundToTheRepositorySession() {
+		String idToUpdate = getNewStringId();
+		Stock toUpdate = newStockWithId(idToUpdate, product_1, QUANTITY_1);
+		Stock notUpdated = newStockWithId(idToUpdate, product_1, QUANTITY_1);
+		saveTestStockToDatabase(toUpdate);
+		toUpdate.setQuantity(QUANTITY_2);
+		session.startTransaction();
+		stockRepository.update(toUpdate);
+		assertThat(readAllStockFromDatabase()).containsExactly(notUpdated);
+		session.commitTransaction();
+	}
+
+	// Private utility methods
+
+	private String getNewStringId() {
+		return new ObjectId().toString();
+	}
+
+	private Stock newStockWithId(String id, Product product, int quantity) {
 		Stock stock = new Stock(product, quantity);
 		stock.setId(id);
 		return stock;
 	}
 
-	private void addTestProductToDatabase(Product product) {
-		Document productDocument = toProductDocument(product);
-		productCollection.insertOne(productDocument);
-		product.setId(productDocument.get("_id").toString());
+	private Document fromStockToDocument(Stock stockWithId) {
+		return new Document().append("_id", new ObjectId(stockWithId.getId()))
+				.append("product", stockWithId.getProduct().getId()).append("quantity", stockWithId.getQuantity());
 	}
 
-	private void addTestProductToDatabaseWithSession(ClientSession session, Product product) {
-		Document productDocument = toProductDocument(product);
-		productCollection.insertOne(session, productDocument);
-		product.setId(productDocument.get("_id").toString());
+	private void saveTestStockToDatabase(Stock stockWithId) {
+		stockCollection.insertOne(fromStockToDocument(stockWithId));
 	}
 
-	private Document toProductDocument(Product product) {
-		return new Document().append("name", product.getName()).append("price", product.getPrice());
+	private void saveTestStockToDatabaseWithSession(ClientSession session, Stock stockWithId) {
+		stockCollection.insertOne(session, fromStockToDocument(stockWithId));
 	}
 
-	private void addTestStockToDatabase(String objectIdString, Product product, int quantity) {
-		stockCollection.insertOne(toStockDocument(objectIdString, product, quantity));
+	private List<Stock> readAllStockFromDatabase() {
+		return StreamSupport.stream(stockCollection.find().spliterator(), false).map(stockDocument -> {
+			String productId = stockDocument.getString("product");
+			Document productDocument = productCollection.find(eq("_id", new ObjectId(productId))).first();
+			Product product = new Product(productDocument.getString("name"), productDocument.getDouble("price"));
+			product.setId(productDocument.get("_id").toString());
+			Stock stock = newStockWithId(stockDocument.get("_id").toString(), product,
+					stockDocument.getInteger("quantity"));
+			return stock;
+		}).collect(Collectors.toList());
 	}
 
-	private void addTestStockToDatabaseWithSession(ClientSession session, String objectIdString, Product product,
-			int quantity) {
-		stockCollection.insertOne(session, toStockDocument(objectIdString, product, quantity));
-
+	private Document fromProductToDocument(Product productWithoutId) {
+		return new Document().append("name", productWithoutId.getName()).append("price", productWithoutId.getPrice());
 	}
 
-	private Document toStockDocument(String objectIdString, Product product, int quantity) {
-		return new Document().append("_id", new ObjectId(objectIdString)).append("product", product.getId())
-				.append("quantity", quantity);
+	private Product saveTestProductToDatabase(Product productWithoutId) {
+		Document doc = fromProductToDocument(productWithoutId);
+		productCollection.insertOne(doc);
+		productWithoutId.setId(doc.get("_id").toString());
+		return productWithoutId;
+	}
+
+	private void saveTestProductToDatabaseWithSession(Product productWithoutId) {
+		Document doc = new Document().append("name", productWithoutId.getName()).append("price",
+				productWithoutId.getPrice());
+		productCollection.insertOne(session, doc);
+		productWithoutId.setId(doc.get("_id").toString());
 	}
 
 }

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepositoryIT.java
@@ -1,0 +1,157 @@
+package com.github.raffaelliscandiffio.repository.mysql;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import javax.persistence.Persistence;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import com.github.raffaelliscandiffio.model.Order;
+import com.github.raffaelliscandiffio.model.OrderItem;
+import com.github.raffaelliscandiffio.model.OrderStatus;
+import com.github.raffaelliscandiffio.model.Product;
+
+@Testcontainers(disabledWithoutDocker = true)
+class OrderItemMySqlRepositoryIT {
+
+	private static final String DATABASE_NAME = "totem";
+	private static final int QUANTITY_1 = 10;
+	private static final int QUANTITY_2 = 20;
+	private static EntityManagerFactory managerFactory;
+
+	private EntityManager entityManager;
+	private OrderItemMySqlRepository orderItemRepository;
+	private Product product_1;
+	private Product product_2;
+	private Order order_1;
+	private Order order_2;
+
+	@Container
+	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
+			.withDatabaseName(DATABASE_NAME).withUsername("mysql").withPassword("mysql");
+
+	@BeforeAll
+	public static void createEntityManagerFactory() {
+		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+		System.setProperty("db.name", DATABASE_NAME);
+		managerFactory = Persistence.createEntityManagerFactory("mysql-test");
+	}
+
+	@AfterAll
+	public static void closeEntityManagerFactory() {
+		managerFactory.close();
+	}
+
+	@BeforeEach
+	void setup() {
+		entityManager = managerFactory.createEntityManager();
+		entityManager.getTransaction().begin();
+		entityManager.createQuery("DELETE FROM OrderItem").executeUpdate();
+		entityManager.createQuery("DELETE FROM Order").executeUpdate();
+		entityManager.createQuery("DELETE FROM Product").executeUpdate();
+		entityManager.getTransaction().commit();
+		orderItemRepository = new OrderItemMySqlRepository(entityManager);
+		product_1 = new Product("product_1", 1.0);
+		product_2 = new Product("product_2", 2.0);
+		order_1 = new Order(OrderStatus.OPEN);
+		order_2 = new Order(OrderStatus.CLOSED);
+		persistObjectToDatabase(product_1);
+		persistObjectToDatabase(product_2);
+		persistObjectToDatabase(order_1);
+		persistObjectToDatabase(order_2);
+	}
+
+	@AfterEach
+	void tearDown() {
+		if (entityManager.isOpen())
+			entityManager.close();
+	}
+
+	@Test
+	@DisplayName("Save OrderItem to database with 'save'")
+	void testSaveOrderItem() {
+		OrderItem item = new OrderItem(product_1, order_1, QUANTITY_1);
+		entityManager.getTransaction().begin();
+		orderItemRepository.save(item);
+		entityManager.getTransaction().commit();
+		String assignedId = item.getId();
+		OrderItem expectedResult = newOrderItemWithId(assignedId, product_1, order_1, QUANTITY_1);
+		assertThat(readAllOrderItemsFromDatabase()).containsExactly(expectedResult);
+	}
+
+	@Test
+	@DisplayName("Find OrderItem by id with 'findById' when the item exists")
+	void testFindByIdWhenIdIsFound() {
+		OrderItem item = new OrderItem(product_1, order_1, QUANTITY_1);
+		OrderItem toFind = new OrderItem(product_2, order_2, QUANTITY_1);
+		persistObjectToDatabase(item);
+		persistObjectToDatabase(toFind);
+		String assignedId = toFind.getId();
+		OrderItem expectedResult = newOrderItemWithId(assignedId, product_2, order_2, QUANTITY_1);
+		assertThat(orderItemRepository.findById(assignedId)).isEqualTo(expectedResult);
+	}
+
+	@Test
+	@DisplayName("Find OrderItem by id with 'findById' when the orderItem does not exist should return null")
+	void testFindByIdWhenIdIsNotFoundShouldReturnNull() {
+		assertThat(orderItemRepository.findById("1")).isNull();
+	}
+
+	@Test
+	@DisplayName("Update orderItem with 'update'")
+	void testUpdateOrderItem() {
+		OrderItem item = new OrderItem(product_1, order_1, QUANTITY_1);
+		OrderItem toUpdate = new OrderItem(product_2, order_2, QUANTITY_1);
+		persistObjectToDatabase(item);
+		persistObjectToDatabase(toUpdate);
+		String assignedId = toUpdate.getId();
+		toUpdate.setQuantity(QUANTITY_2);
+		entityManager.getTransaction().begin();
+		orderItemRepository.update(toUpdate);
+		entityManager.getTransaction().commit();
+		OrderItem expectedResult = newOrderItemWithId(assignedId, product_2, order_2, QUANTITY_2);
+		assertThat(readAllOrderItemsFromDatabase()).containsExactlyInAnyOrder(item, expectedResult);
+	}
+
+	@Test
+	@DisplayName("Delete OrderItem by id with 'delete'")
+	void testDeleteOrderItem() {
+		OrderItem item = new OrderItem(product_1, order_1, QUANTITY_1);
+		OrderItem toDelete = new OrderItem(product_2, order_2, QUANTITY_1);
+		persistObjectToDatabase(item);
+		persistObjectToDatabase(toDelete);
+		String idToDelete = toDelete.getId();
+		entityManager.getTransaction().begin();
+		orderItemRepository.delete(idToDelete);
+		entityManager.getTransaction().commit();
+		assertThat(readAllOrderItemsFromDatabase()).containsExactly(item);
+	}
+
+	private void persistObjectToDatabase(Object object) {
+		entityManager.getTransaction().begin();
+		entityManager.persist(object);
+		entityManager.getTransaction().commit();
+	}
+
+	private List<OrderItem> readAllOrderItemsFromDatabase() {
+		return entityManager.createQuery("SELECT item FROM OrderItem item", OrderItem.class).getResultList();
+	}
+
+	private OrderItem newOrderItemWithId(String id, Product product, Order order, int quantity) {
+		OrderItem item = new OrderItem(product, order, quantity);
+		item.setId(id);
+		return item;
+	}
+}

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongoIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongoIT.java
@@ -77,8 +77,8 @@ class TransactionManagerMongoIT {
 							.isEqualTo(new ProductMongoRepository(client, session, DB_NAME, PRODUCT_COLLECTION_NAME));
 					softly.assertThat(stockRepository).usingRecursiveComparison().isEqualTo(new StockMongoRepository(
 							client, session, DB_NAME, PRODUCT_COLLECTION_NAME, STOCK_COLLECTION_NAME));
-					softly.assertThat(orderRepository).usingRecursiveComparison()
-							.isEqualTo(new OrderMongoRepository(client, session, DB_NAME, ORDER_COLLECTION_NAME));
+					softly.assertThat(orderRepository).usingRecursiveComparison().isEqualTo(new OrderMongoRepository(
+							client, session, DB_NAME, ORDER_COLLECTION_NAME, ORDER_ITEM_COLLECTION_NAME));
 					softly.assertThat(orderItemRepository).usingRecursiveComparison()
 							.isEqualTo(new OrderItemMongoRepository(client, session, DB_NAME, PRODUCT_COLLECTION_NAME,
 									ORDER_COLLECTION_NAME, ORDER_ITEM_COLLECTION_NAME));

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongoIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongoIT.java
@@ -74,8 +74,8 @@ class TransactionManagerMongoIT {
 					.isEqualTo(new ProductMongoRepository(client, session, DB_NAME, PRODUCT_COLLECTION_NAME));
 			softly.assertThat(stockRepository).usingRecursiveComparison().isEqualTo(
 					new StockMongoRepository(client, session, DB_NAME, PRODUCT_COLLECTION_NAME, STOCK_COLLECTION_NAME));
-			softly.assertThat(orderRepository).usingRecursiveComparison().isEqualTo(
-					new OrderMongoRepository(client, session, DB_NAME, PRODUCT_COLLECTION_NAME, ORDER_COLLECTION_NAME));
+			softly.assertThat(orderRepository).usingRecursiveComparison()
+					.isEqualTo(new OrderMongoRepository(client, session, DB_NAME, ORDER_COLLECTION_NAME));
 			productCollection.insertOne(session, productToDocument(product));
 			return product;
 		});

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/model/Order.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/model/Order.java
@@ -1,16 +1,13 @@
 package com.github.raffaelliscandiffio.model;
 
 import java.util.Objects;
-import java.util.Set;
 
 public class Order {
 
 	private String id;
-	private Set<OrderItem> items;
 	private OrderStatus status;
 
-	public Order(Set<OrderItem> items, OrderStatus status) {
-		this.items = items;
+	public Order(OrderStatus status) {
 		this.status = status;
 	}
 
@@ -20,14 +17,6 @@ public class Order {
 
 	public void setId(String id) {
 		this.id = id;
-	}
-
-	public Set<OrderItem> getItems() {
-		return items;
-	}
-
-	public void setItems(Set<OrderItem> items) {
-		this.items = items;
 	}
 
 	public OrderStatus getStatus() {
@@ -40,7 +29,7 @@ public class Order {
 
 	@Override
 	public int hashCode() {
-		return Objects.hash(id, items, status);
+		return Objects.hash(id, status);
 	}
 
 	@Override
@@ -52,7 +41,7 @@ public class Order {
 		if (getClass() != obj.getClass())
 			return false;
 		Order other = (Order) obj;
-		return Objects.equals(id, other.id) && Objects.equals(items, other.items) && status == other.status;
+		return Objects.equals(id, other.id) && status == other.status;
 	}
 
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/model/OrderItem.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/model/OrderItem.java
@@ -4,19 +4,25 @@ import java.util.Objects;
 
 public class OrderItem {
 
+	private String id;
 	private Product product;
+	private Order order;
 	private int quantity;
 	private double subTotal;
 
-	// JPA uses this to initialise an embedded OrderItem
-	@SuppressWarnings("unused")
-	private OrderItem() {
-	}
-
-	public OrderItem(Product product, int quantity) {
+	public OrderItem(Product product, Order order, int quantity) {
 		this.product = product;
+		this.order = order;
 		this.quantity = quantity;
 		this.subTotal = quantity * product.getPrice();
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	public int getQuantity() {
@@ -25,23 +31,25 @@ public class OrderItem {
 
 	public void setQuantity(int quantity) {
 		this.quantity = quantity;
-	}
+		this.subTotal = quantity * product.getPrice();
 
-	public double getSubTotal() {
-		return subTotal;
-	}
-
-	public void setSubTotal(double subTotal) {
-		this.subTotal = subTotal;
 	}
 
 	public Product getProduct() {
 		return product;
 	}
 
+	public Order getOrder() {
+		return order;
+	}
+
+	public double getSubTotal() {
+		return subTotal;
+	}
+
 	@Override
 	public int hashCode() {
-		return Objects.hash(product);
+		return Objects.hash(id, order, product, quantity);
 	}
 
 	@Override
@@ -53,7 +61,8 @@ public class OrderItem {
 		if (getClass() != obj.getClass())
 			return false;
 		OrderItem other = (OrderItem) obj;
-		return Objects.equals(product, other.product);
+		return Objects.equals(id, other.id) && Objects.equals(order, other.order)
+				&& Objects.equals(product, other.product) && quantity == other.quantity;
 	}
 
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/OrderItemRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/OrderItemRepository.java
@@ -1,0 +1,14 @@
+package com.github.raffaelliscandiffio.repository;
+
+import com.github.raffaelliscandiffio.model.OrderItem;
+
+public interface OrderItemRepository {
+
+	void save(OrderItem orderItem);
+
+	OrderItem findById(String id);
+
+	void delete(String id);
+
+	void update(OrderItem orderItem);
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/OrderRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/OrderRepository.java
@@ -8,7 +8,7 @@ public interface OrderRepository {
 
 	Order findById(String id);
 
-	void delete(Order order);
+	void delete(String id);
 
 	void update(Order order);
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
@@ -1,6 +1,7 @@
 package com.github.raffaelliscandiffio.repository.mongo;
 
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
 
 import java.util.NoSuchElementException;
 
@@ -16,6 +17,7 @@ import com.github.raffaelliscandiffio.repository.OrderItemRepository;
 import com.mongodb.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.result.UpdateResult;
 
 public class OrderItemMongoRepository implements OrderItemRepository {
 
@@ -84,7 +86,11 @@ public class OrderItemMongoRepository implements OrderItemRepository {
 
 	@Override
 	public void update(OrderItem orderItem) {
-		// TODO Auto-generated method stub
+		Bson update = set(FIELD_QUANTITY, orderItem.getQuantity());
+		String id = orderItem.getId();
+		UpdateResult result = orderItemCollection.updateOne(session, eqFilter(id), update);
+		if (result.getMatchedCount() == 0)
+			throw new NoSuchElementException("OrderItem with id " + id + " not found.");
 
 	}
 

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
@@ -78,7 +78,7 @@ public class OrderItemMongoRepository implements OrderItemRepository {
 
 	@Override
 	public void delete(String id) {
-		// TODO Auto-generated method stub
+		orderItemCollection.deleteOne(session, eqFilter(id));
 
 	}
 

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
@@ -1,0 +1,77 @@
+package com.github.raffaelliscandiffio.repository.mongo;
+
+import static com.mongodb.client.model.Filters.eq;
+
+import java.util.NoSuchElementException;
+
+import org.bson.Document;
+import org.bson.conversions.Bson;
+import org.bson.types.ObjectId;
+
+import com.github.raffaelliscandiffio.model.OrderItem;
+import com.github.raffaelliscandiffio.repository.OrderItemRepository;
+import com.mongodb.MongoClient;
+import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoCollection;
+
+public class OrderItemMongoRepository implements OrderItemRepository {
+
+	private static final String FIELD_ID = "_id";
+	private static final String FIELD_PRODUCT = "product";
+	private static final String FIELD_ORDER = "order";
+	private static final String FIELD_QUANTITY = "quantity";
+
+	private ClientSession session;
+	private MongoCollection<Document> productCollection;
+	private MongoCollection<Document> orderCollection;
+	private MongoCollection<Document> orderItemCollection;
+
+	public OrderItemMongoRepository(MongoClient client, ClientSession session, String databaseName,
+			String productCollectionName, String orderCollectionName, String orderItemCollectionName) {
+		this.session = session;
+		this.productCollection = client.getDatabase(databaseName).getCollection(productCollectionName);
+		this.orderCollection = client.getDatabase(databaseName).getCollection(orderCollectionName);
+		this.orderItemCollection = client.getDatabase(databaseName).getCollection(orderItemCollectionName);
+	}
+
+	@Override
+	public void save(OrderItem orderItem) {
+		String productId = orderItem.getProduct().getId();
+		if (productCollection.find(eqFilter(productId)).first() == null)
+			throw new NoSuchElementException(
+					"Reference error, cannot save OrderItem: Product with " + productId + " not found.");
+
+		String orderId = orderItem.getOrder().getId();
+		if (orderCollection.find(session, eqFilter(orderId)).first() == null)
+			throw new NoSuchElementException(
+					"Reference error, cannot save OrderItem: Order with " + orderId + " not found.");
+
+		Document doc = new Document().append(FIELD_PRODUCT, orderItem.getProduct().getId())
+				.append(FIELD_ORDER, orderItem.getOrder().getId()).append(FIELD_QUANTITY, orderItem.getQuantity());
+		orderItemCollection.insertOne(session, doc);
+		orderItem.setId(doc.get(FIELD_ID).toString());
+	}
+
+	@Override
+	public OrderItem findById(String id) {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
+	@Override
+	public void delete(String id) {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void update(OrderItem orderItem) {
+		// TODO Auto-generated method stub
+
+	}
+
+	private Bson eqFilter(String id) {
+		return eq(FIELD_ID, new ObjectId(id));
+	}
+
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepository.java
@@ -1,102 +1,66 @@
 package com.github.raffaelliscandiffio.repository.mongo;
 
 import static com.mongodb.client.model.Filters.eq;
-import static com.mongodb.client.model.Updates.combine;
 import static com.mongodb.client.model.Updates.set;
 
-import java.util.ArrayList;
-import java.util.LinkedHashSet;
-import java.util.List;
 import java.util.NoSuchElementException;
-import java.util.Set;
 
 import org.bson.Document;
 import org.bson.conversions.Bson;
 import org.bson.types.ObjectId;
 
 import com.github.raffaelliscandiffio.model.Order;
-import com.github.raffaelliscandiffio.model.OrderItem;
 import com.github.raffaelliscandiffio.model.OrderStatus;
-import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.repository.OrderRepository;
 import com.mongodb.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.result.UpdateResult;
 
 public class OrderMongoRepository implements OrderRepository {
 
 	private static final String FIELD_ID = "_id";
-	private static final String FIELD_ITEMS = "items";
-	private static final String FIELD_NAME = "name";
-	private static final String FIELD_PRICE = "price";
-	private static final String FIELD_PRODUCT = "product";
-	private static final String FIELD_QUANTITY = "quantity";
 	private static final String FIELD_STATUS = "status";
 
 	private ClientSession session;
-	private MongoCollection<Document> productCollection;
 	private MongoCollection<Document> orderCollection;
 
 	public OrderMongoRepository(MongoClient client, ClientSession session, String databaseName,
-			String productCollectionName, String orderCollectionName) {
+			String orderCollectionName) {
 		this.session = session;
-		productCollection = client.getDatabase(databaseName).getCollection(productCollectionName);
-		orderCollection = client.getDatabase(databaseName).getCollection(orderCollectionName);
+		this.orderCollection = client.getDatabase(databaseName).getCollection(orderCollectionName);
 	}
 
+	@Override
 	public void save(Order order) {
-		List<Document> embeddedItems = orderItemSetToDocumentList(order.getItems());
-		Document orderDocument = new Document().append(FIELD_ITEMS, embeddedItems).append(FIELD_STATUS,
-				order.getStatus().toString());
+		Document orderDocument = new Document().append(FIELD_STATUS, order.getStatus().toString());
 		orderCollection.insertOne(session, orderDocument);
 		order.setId(orderDocument.get(FIELD_ID).toString());
 	}
 
 	@Override
 	public Order findById(String id) {
-		Document orderDocument = findDocumentById(id);
-		if (orderDocument == null)
+		Document doc = orderCollection.find(session, eqFilter(id)).first();
+		if (doc == null)
 			return null;
-		List<Document> itemDocuments = orderDocument.getList(FIELD_ITEMS, Document.class);
-		List<OrderItem> items = new ArrayList<>();
-		Document productDocument;
-		for (Document itemDocument : itemDocuments) {
-			String productId = itemDocument.getString(FIELD_PRODUCT);
-			productDocument = productCollection.find(eqFilter(productId)).first();
-			Product product = new Product(productDocument.getString(FIELD_NAME),
-					productDocument.getDouble(FIELD_PRICE));
-			product.setId(productId);
-			items.add(new OrderItem(product, itemDocument.getInteger(FIELD_QUANTITY)));
-		}
-		Order order = new Order(new LinkedHashSet<>(items), OrderStatus.valueOf(orderDocument.getString(FIELD_STATUS)));
-		order.setId(orderDocument.get(FIELD_ID).toString());
+		Order order = new Order(OrderStatus.valueOf(doc.getString(FIELD_STATUS)));
+		order.setId(id);
 		return order;
 	}
 
 	@Override
-	public void delete(Order order) {
-		orderCollection.deleteOne(session, eqFilter(order.getId()));
+	public void delete(String id) {
+		orderCollection.deleteOne(session, eqFilter(id));
 	}
 
 	@Override
 	public void update(Order order) {
-		String orderId = order.getId();
-		if (findDocumentById(orderId) == null)
-			throw new NoSuchElementException("Order with id " + orderId + " not found.");
-		List<Document> embeddedItems = orderItemSetToDocumentList(order.getItems());
-		Bson update = combine(set(FIELD_ITEMS, embeddedItems), set(FIELD_STATUS, order.getStatus().toString()));
-		orderCollection.updateOne(session, eqFilter(orderId), update);
-	}
+		Bson update = set(FIELD_STATUS, order.getStatus().toString());
+		String id = order.getId();
+		UpdateResult result = orderCollection.updateOne(session, eqFilter(id), update);
+		if (result.getMatchedCount() == 0)
+			throw new NoSuchElementException("Order with id " + id + " not found.");
 
-	private Document findDocumentById(String orderId) {
-		return orderCollection.find(session, eqFilter(orderId)).first();
-	}
-
-	private List<Document> orderItemSetToDocumentList(Set<OrderItem> items) {
-		List<Document> embeddedItems = new ArrayList<>();
-		items.forEach(item -> embeddedItems.add(new Document().append(FIELD_PRODUCT, item.getProduct().getId())
-				.append(FIELD_QUANTITY, item.getQuantity())));
-		return embeddedItems;
 	}
 
 	private Bson eqFilter(String id) {

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepository.java
@@ -46,7 +46,7 @@ public class ProductMongoRepository implements ProductRepository {
 
 	@Override
 	public Product findById(String id) {
-		Document d = productCollection.find(Filters.eq(FIELD_ID, new ObjectId(id))).first();
+		Document d = productCollection.find(session, Filters.eq(FIELD_ID, new ObjectId(id))).first();
 		if (d != null)
 			return fromDocumentToProduct(d);
 		else

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepository.java
@@ -1,6 +1,9 @@
 package com.github.raffaelliscandiffio.repository.mongo;
 
 import static com.mongodb.client.model.Filters.eq;
+import static com.mongodb.client.model.Updates.set;
+
+import java.util.NoSuchElementException;
 
 import org.bson.Document;
 import org.bson.conversions.Bson;
@@ -12,6 +15,7 @@ import com.github.raffaelliscandiffio.repository.StockRepository;
 import com.mongodb.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
+import com.mongodb.client.result.UpdateResult;
 
 public class StockMongoRepository implements StockRepository {
 
@@ -56,8 +60,11 @@ public class StockMongoRepository implements StockRepository {
 
 	@Override
 	public void update(Stock stock) {
-		Document updateQuery = new Document("$set", new Document(FIELD_QUANTITY, stock.getQuantity()));
-		stockCollection.updateOne(session, eqFilter(stock.getId()), updateQuery);
+		Bson update = set(FIELD_QUANTITY, stock.getQuantity());
+		String id = stock.getId();
+		UpdateResult result = stockCollection.updateOne(session, eqFilter(id), update);
+		if (result.getMatchedCount() == 0)
+			throw new NoSuchElementException("Stock with id " + id + " not found.");
 	}
 
 	private Bson eqFilter(String id) {

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepository.java
@@ -1,0 +1,37 @@
+package com.github.raffaelliscandiffio.repository.mysql;
+
+import javax.persistence.EntityManager;
+
+import com.github.raffaelliscandiffio.model.OrderItem;
+import com.github.raffaelliscandiffio.repository.OrderItemRepository;
+
+public class OrderItemMySqlRepository implements OrderItemRepository {
+
+	private EntityManager entityManager;
+
+	public OrderItemMySqlRepository(EntityManager entityManager) {
+		this.entityManager = entityManager;
+	}
+
+	@Override
+	public void save(OrderItem orderItem) {
+		entityManager.persist(orderItem);
+	}
+
+	@Override
+	public OrderItem findById(String id) {
+		return entityManager.find(OrderItem.class, id);
+	}
+
+	@Override
+	public void delete(String id) {
+		entityManager.createQuery("DELETE FROM OrderItem where id=:item_id").setParameter("item_id", id)
+				.executeUpdate();
+	}
+
+	@Override
+	public void update(OrderItem orderItem) {
+		entityManager.merge(orderItem);
+	}
+
+}

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mysql/OrderMySqlRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mysql/OrderMySqlRepository.java
@@ -29,8 +29,8 @@ public class OrderMySqlRepository implements OrderRepository {
 	}
 
 	@Override
-	public void delete(Order order) {
-		entityManager.remove(order);
+	public void delete(String id) {
+		entityManager.createQuery("DELETE FROM Order where id=:order_id").setParameter("order_id", id).executeUpdate();
 	}
 
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/TransactionCode.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/TransactionCode.java
@@ -1,5 +1,6 @@
 package com.github.raffaelliscandiffio.transaction;
 
+import com.github.raffaelliscandiffio.repository.OrderItemRepository;
 import com.github.raffaelliscandiffio.repository.OrderRepository;
 import com.github.raffaelliscandiffio.repository.ProductRepository;
 import com.github.raffaelliscandiffio.repository.StockRepository;
@@ -7,6 +8,7 @@ import com.github.raffaelliscandiffio.repository.StockRepository;
 @FunctionalInterface
 public interface TransactionCode<T> {
 
-	T apply(ProductRepository productRepository, StockRepository stockRepository, OrderRepository orderRepository);
+	T apply(ProductRepository productRepository, StockRepository stockRepository, OrderRepository orderRepository,
+			OrderItemRepository orderItemRepository);
 
 }

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
@@ -35,8 +35,7 @@ public class TransactionManagerMongo implements TransactionManager {
 			T result = code.apply(new ProductMongoRepository(client, session, mongoDatabaseName, productCollectionName),
 					new StockMongoRepository(client, session, mongoDatabaseName, productCollectionName,
 							stockCollectionName),
-					new OrderMongoRepository(client, session, mongoDatabaseName, productCollectionName,
-							orderCollectionName));
+					new OrderMongoRepository(client, session, mongoDatabaseName, orderCollectionName));
 			session.commitTransaction();
 			return result;
 		} catch (Exception e) {

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
@@ -1,5 +1,6 @@
 package com.github.raffaelliscandiffio.transaction.mongo;
 
+import com.github.raffaelliscandiffio.repository.mongo.OrderItemMongoRepository;
 import com.github.raffaelliscandiffio.repository.mongo.OrderMongoRepository;
 import com.github.raffaelliscandiffio.repository.mongo.ProductMongoRepository;
 import com.github.raffaelliscandiffio.repository.mongo.StockMongoRepository;
@@ -16,15 +17,18 @@ public class TransactionManagerMongo implements TransactionManager {
 	private final String productCollectionName;
 	private final String stockCollectionName;
 	private final String orderCollectionName;
+	private final String orderItemCollectionName;
 	private ClientSession session;
 
 	public TransactionManagerMongo(MongoClient client, String dbName, String productCollectionName,
-			String stockCollectionName, String orderCollectionName) {
+			String stockCollectionName, String orderCollectionName, String orderItemCollectionName) {
 		this.client = client;
 		this.mongoDatabaseName = dbName;
 		this.productCollectionName = productCollectionName;
 		this.stockCollectionName = stockCollectionName;
 		this.orderCollectionName = orderCollectionName;
+		this.orderItemCollectionName = orderItemCollectionName;
+
 	}
 
 	@Override
@@ -35,7 +39,9 @@ public class TransactionManagerMongo implements TransactionManager {
 			T result = code.apply(new ProductMongoRepository(client, session, mongoDatabaseName, productCollectionName),
 					new StockMongoRepository(client, session, mongoDatabaseName, productCollectionName,
 							stockCollectionName),
-					new OrderMongoRepository(client, session, mongoDatabaseName, orderCollectionName));
+					new OrderMongoRepository(client, session, mongoDatabaseName, orderCollectionName),
+					new OrderItemMongoRepository(client, session, mongoDatabaseName, productCollectionName,
+							orderCollectionName, orderItemCollectionName));
 			session.commitTransaction();
 			return result;
 		} catch (Exception e) {

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
@@ -39,7 +39,8 @@ public class TransactionManagerMongo implements TransactionManager {
 			T result = code.apply(new ProductMongoRepository(client, session, mongoDatabaseName, productCollectionName),
 					new StockMongoRepository(client, session, mongoDatabaseName, productCollectionName,
 							stockCollectionName),
-					new OrderMongoRepository(client, session, mongoDatabaseName, orderCollectionName),
+					new OrderMongoRepository(client, session, mongoDatabaseName, orderCollectionName,
+							orderItemCollectionName),
 					new OrderItemMongoRepository(client, session, mongoDatabaseName, productCollectionName,
 							orderCollectionName, orderItemCollectionName));
 			session.commitTransaction();

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mysql/TransactionManagerMySql.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mysql/TransactionManagerMySql.java
@@ -2,6 +2,7 @@ package com.github.raffaelliscandiffio.transaction.mysql;
 
 import javax.persistence.EntityManager;
 
+import com.github.raffaelliscandiffio.repository.mysql.OrderItemMySqlRepository;
 import com.github.raffaelliscandiffio.repository.mysql.OrderMySqlRepository;
 import com.github.raffaelliscandiffio.repository.mysql.ProductMySqlRepository;
 import com.github.raffaelliscandiffio.repository.mysql.StockMySqlRepository;
@@ -22,7 +23,7 @@ public class TransactionManagerMySql implements TransactionManager {
 		try {
 			entityManager.getTransaction().begin();
 			T result = code.apply(new ProductMySqlRepository(entityManager), new StockMySqlRepository(entityManager),
-					new OrderMySqlRepository(entityManager));
+					new OrderMySqlRepository(entityManager), new OrderItemMySqlRepository(entityManager));
 			entityManager.getTransaction().commit();
 			return result;
 		} catch (Exception e) {

--- a/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/Order.hbm.xml
+++ b/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/Order.hbm.xml
@@ -9,12 +9,5 @@
 			<generator class="uuid2"/>
 		</id>
 		<property name="status" type="com.github.raffaelliscandiffio.model.OrderStatus"/>
-		<set name="items" table="order_items" lazy="false" access="field">
-			<key on-delete="cascade" column="order_id"/>
-			<composite-element class="com.github.raffaelliscandiffio.model.OrderItem">
-				<property name="quantity" access="field"/>
-				<many-to-one name="product" class="com.github.raffaelliscandiffio.model.Product" access="field"/>
-			</composite-element>
-		</set>
 	</class>
 </hibernate-mapping>

--- a/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/OrderItem.hbm.xml
+++ b/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/OrderItem.hbm.xml
@@ -1,0 +1,16 @@
+<?xml version = "1.0" encoding = "utf-8"?>
+<!DOCTYPE hibernate-mapping PUBLIC 
+"-//Hibernate/Hibernate Mapping DTD//EN"
+"http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+
+<hibernate-mapping>
+	<class name="com.github.raffaelliscandiffio.model.OrderItem" table="ORDER_ITEMS">
+
+		<id name="id" type="string" access="field">
+			<generator class="uuid2"/>
+		</id>
+		<property name="quantity" column="quantity" type="int" access="field"/>
+		<one-to-one name="product" class="com.github.raffaelliscandiffio.model.Product" access="field"></one-to-one>
+		<many-to-one name="order" class="com.github.raffaelliscandiffio.model.Order" column="order_id"  access="field"></many-to-one>
+	</class>
+</hibernate-mapping>

--- a/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/persistence.xml
+++ b/raffaelliscandiffio.shop-totem/src/main/resources/META-INF/persistence.xml
@@ -10,10 +10,12 @@
 		<mapping-file>/META-INF/Product.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/Stock.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/Order.hbm.xml</mapping-file>
+		<mapping-file>/META-INF/OrderItem.hbm.xml</mapping-file>
 		
 		<class>com.github.raffaelliscandiffio.model.Product</class>
 		<class>com.github.raffaelliscandiffio.model.Stock</class>
 		<class>com.github.raffaelliscandiffio.model.Order</class>
+		<class>com.github.raffaelliscandiffio.model.OrderItem</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		
 		<properties>

--- a/raffaelliscandiffio.shop-totem/src/test/java/com/github/raffaelliscandiffio/view/swing/TotemSwingViewTest.java
+++ b/raffaelliscandiffio.shop-totem/src/test/java/com/github/raffaelliscandiffio/view/swing/TotemSwingViewTest.java
@@ -29,7 +29,9 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.github.raffaelliscandiffio.controller.TotemController;
+import com.github.raffaelliscandiffio.model.Order;
 import com.github.raffaelliscandiffio.model.OrderItem;
+import com.github.raffaelliscandiffio.model.OrderStatus;
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.utils.GUITestExtension;
 
@@ -392,9 +394,9 @@ class TotemSwingViewTest {
 			@GUITest
 			@DisplayName("Method 'itemAdded' should add the received OrderItem element to the cart list")
 			void testItemAddedShouldAddTheOrderItemToTheCartList() {
-				OrderItem newItem = new OrderItem(new Product("Product2", 2.0), 4);
+				OrderItem newItem = new OrderItem(new Product("Product2", 2.0), new Order(OrderStatus.OPEN), 4);
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product1", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5)));
 
 				GuiActionRunner.execute(() -> totemSwingView.itemAdded(newItem));
 				String[] listContents = window.list("cartList").contents();
@@ -407,11 +409,11 @@ class TotemSwingViewTest {
 			@DisplayName("Method 'itemModified' should update the specified item in the cart list")
 			void testItemModifiedShouldUpdateTheOldOrderItemWithTheNewOneInCartList() {
 				Product product = new Product("Product2", 3.0);
-				OrderItem oldItem = new OrderItem(product, 4);
-				OrderItem updatedItem = new OrderItem(product, 5);
+				OrderItem oldItem = new OrderItem(product, new Order(OrderStatus.OPEN), 4);
+				OrderItem updatedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
-					itemsModel.addElement(new OrderItem(new Product("Product1", 2.0), 5));
+					itemsModel.addElement(new OrderItem(new Product("Product1", 2.0), new Order(OrderStatus.OPEN), 5));
 					itemsModel.addElement(oldItem);
 				});
 				GuiActionRunner.execute(() -> totemSwingView.itemModified(oldItem, updatedItem));
@@ -427,8 +429,8 @@ class TotemSwingViewTest {
 			void testAllItemsRemovedShouldClearTheCartList() {
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
-					itemsModel.addElement(new OrderItem(new Product("Product1", 2.0), 5));
-					itemsModel.addElement(new OrderItem(new Product("Product2", 2.0), 4));
+					itemsModel.addElement(new OrderItem(new Product("Product1", 2.0), new Order(OrderStatus.OPEN), 5));
+					itemsModel.addElement(new OrderItem(new Product("Product2", 2.0), new Order(OrderStatus.OPEN), 4));
 				});
 				GuiActionRunner.execute(() -> totemSwingView.allItemsRemoved());
 				String[] listContents = window.list("cartList").contents();
@@ -439,8 +441,8 @@ class TotemSwingViewTest {
 			@GUITest
 			@DisplayName("Method 'showErrorItemNotFound' should set error message label and delete the item from the cart list")
 			void testShowErrorItemNotFoundShouldSetMessageLabelAndDeleteItemFromCartList() {
-				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), 5);
-				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), 4);
+				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5);
+				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), new Order(OrderStatus.OPEN), 4);
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 					itemsModel.addElement(item1);
@@ -456,8 +458,8 @@ class TotemSwingViewTest {
 			@GUITest
 			@DisplayName("Method 'showErrorEmptyOrder' should set error message label and clear the cart list")
 			void testShowErrorEmptyOrderShouldSetMessageLabelAndClearTheCartList() {
-				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), 5);
-				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), 4);
+				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5);
+				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), new Order(OrderStatus.OPEN), 4);
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 					itemsModel.addElement(item1);
@@ -488,10 +490,10 @@ class TotemSwingViewTest {
 			@GUITest
 			@DisplayName("Method 'itemRemoved' should remove the specified OrderItem from the cart")
 			void testItemRemovedShouldRemoveTheOrderItemFromTheCart() {
-				OrderItem toRemove = new OrderItem(new Product("Product2", 2.0), 4);
+				OrderItem toRemove = new OrderItem(new Product("Product2", 2.0), new Order(OrderStatus.OPEN), 4);
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
-					itemsModel.addElement(new OrderItem(new Product("Product1", 3.0), 5));
+					itemsModel.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5));
 					itemsModel.addElement(toRemove);
 				});
 				GuiActionRunner.execute(() -> totemSwingView.itemRemoved(toRemove));
@@ -533,7 +535,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'Remove selected' should be enabled only when an OrderItem is selected")
 			void testRemoveSelectedButtonShouldBeEnabledOnlyWhenAnOrderItemIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				JButtonFixture buttonAdd = window.button(JButtonMatcher.withText("Remove selected"));
 				buttonAdd.requireEnabled();
@@ -544,8 +546,8 @@ class TotemSwingViewTest {
 			@Test
 			@DisplayName("Button 'Remove selected' should delegate to TotemController 'removeItem'")
 			void testRemoveSelectedButtonShouldDelegateToTotemControllerRemoveItem() {
-				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), 5);
-				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), 4);
+				OrderItem item1 = new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5);
+				OrderItem item2 = new OrderItem(new Product("Product2", 1.0), new Order(OrderStatus.OPEN), 4);
 				JButtonFixture removeButton = window.button(JButtonMatcher.withText("Remove selected"));
 				GuiActionRunner.execute(() -> {
 					DefaultListModel<OrderItem> listItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
@@ -569,7 +571,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'Checkout' should be enabled when an item is added to the cart list")
 			void testCheckoutButtonShouldBeEnabledWhenAnItemIsAddedToCartList() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product1", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.button(JButtonMatcher.withText("Checkout")).requireEnabled();
 			}
 
@@ -588,8 +590,8 @@ class TotemSwingViewTest {
 				DefaultListModel<OrderItem> itemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				JButtonFixture checkoutButton = window.button(JButtonMatcher.withText("Checkout"));
 				GuiActionRunner.execute(() -> {
-					itemsModel.addElement(new OrderItem(new Product("Product1", 3.0), 5));
-					itemsModel.addElement(new OrderItem(new Product("Product2", 3.0), 5));
+					itemsModel.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5));
+					itemsModel.addElement(new OrderItem(new Product("Product2", 3.0), new Order(OrderStatus.OPEN), 5));
 					checkoutButton.target().setEnabled(true);
 				});
 
@@ -616,7 +618,7 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner should be enabled when an item is selected and the item quantity is greater than one")
 			void testTheSpinnerShouldBeEnabledWhenAnItemWithQuantityGreaterThanOneIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product1", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").requireEnabled();
 			}
@@ -626,7 +628,7 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner should be disabled when an item is selected and the item quantity is one")
 			void testTheSpinnerShouldBeDisabeldWhenAnItemWithQuantityEqualToOneIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 1)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 1)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").requireDisabled();
 			}
@@ -636,7 +638,7 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner should be disabled when an item is deselected")
 			void testTheSpinnerShouldBeDisabeldWhenAnItemIsDeselected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product1", 3), 5)));
+						.addElement(new OrderItem(new Product("Product1", 3), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.list("cartList").clearSelection();
 				window.spinner("cartReturnSpinner").requireDisabled();
@@ -648,9 +650,9 @@ class TotemSwingViewTest {
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> {
 					totemSwingView.getCartPane().getListOrderItemsModel()
-							.addElement(new OrderItem(new Product("Product1", 3), 5));
+							.addElement(new OrderItem(new Product("Product1", 3), new Order(OrderStatus.OPEN), 5));
 					totemSwingView.getCartPane().getListOrderItemsModel()
-							.addElement(new OrderItem(new Product("Product2", 3), 5));
+							.addElement(new OrderItem(new Product("Product2", 3), new Order(OrderStatus.OPEN), 5));
 				});
 				window.list("cartList").selectItem(0);
 				cartSpinner.enterTextAndCommit("2");
@@ -663,7 +665,7 @@ class TotemSwingViewTest {
 			void testTheSpinnerValueShouldBeResetToOneWhenAnItemIsDeselected() {
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3), 5)));
+						.addElement(new OrderItem(new Product("Product", 3), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				cartSpinner.enterTextAndCommit("2");
 				window.list("cartList").clearSelection();
@@ -674,8 +676,8 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner value should be reset to one when an item is selected and the item quantity changes to one")
 			void testTheSpinnerValueShouldBeResetToOneWhenAnItemIsSelectedAndTheItemQuantityChangesToOne() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 10);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
@@ -689,12 +691,13 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner value should not be reset to one when an item is selected and another item quantity changes to one")
 			void testTheSpinnerValueShouldNotBeResetToOneWhenAnItemIsSelectedAndAnotherItemQuantityChangesToOne() {
 				Product product = new Product("Product2", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> {
-					listOrderItemsModel.addElement(new OrderItem(new Product("Product1", 3.0), 5));
+					listOrderItemsModel
+							.addElement(new OrderItem(new Product("Product1", 3.0), new Order(OrderStatus.OPEN), 5));
 					listOrderItemsModel.addElement(storedItem);
 				});
 				window.list("cartList").selectItem(0);
@@ -707,8 +710,8 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner should be disabled when an item is selected and the item quantity changes to one")
 			void testTheSpinnerShouldBeDisabledWhenAnItemIsSelectedAndTheItemQuantityChangesToOne() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 10);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
@@ -722,8 +725,8 @@ class TotemSwingViewTest {
 			@DisplayName("The spinner should be enabled when an item with value one is selected and the item quantity increases")
 			void testTheSpinnerShouldBeEnabledWhenAnItemWithQuantityOneIsSelectedAndTheItemQuantityIncreases() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 1);
-				OrderItem modifiedItem = new OrderItem(product, 5);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				JSpinnerFixture cartSpinner = window.spinner("cartReturnSpinner");
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
@@ -742,7 +745,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be enabled when an item is selected and the item quantity is greater than one")
 			void testButtonReturnQuantityShouldBeEnabledWhenAnItemWithQuantityGreaterThanOneIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.button(JButtonMatcher.withText("Return quantity")).requireEnabled();
 			}
@@ -752,7 +755,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be disabled when an item is selected and the item quantity is one")
 			void testButtonReturnQuantityShouldBeDisabledWhenAnItemWithQuantityEqualToOneIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 1)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 1)));
 				window.list("cartList").selectItem(0);
 				window.button(JButtonMatcher.withText("Return quantity")).requireDisabled();
 			}
@@ -762,7 +765,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be disabled when no item is selected")
 			void testButtonReturnQuantityShouldBeDisabledWhenNoItemIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.list("cartList").clearSelection();
 				window.button(JButtonMatcher.withText("Return quantity")).requireDisabled();
@@ -775,7 +778,7 @@ class TotemSwingViewTest {
 			void testReturnQuantityButtonShouldBeDisabledWhenValueInSpinnerIsNotAPositiveIntegerOrStartsWithZero(
 					String input) {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText(input);
 				window.button(JButtonMatcher.withText("Return quantity")).requireDisabled();
@@ -786,7 +789,7 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be enabled when an item is selected and the spinner text is less than the item quantity")
 			void testReturnQuantityButtonShouldBeEnabledWhenAnItemIsSelectedAndSpinnerTextIsLessThanTheSelectedItemQuantity() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText("4");
 				window.button(JButtonMatcher.withText("Return quantity")).requireEnabled();
@@ -798,7 +801,7 @@ class TotemSwingViewTest {
 			void testReturnQuantityButtonShouldBeDisabledWhenAnItemIsSelectedAndSpinnerTextIsEqualToOrGreaterThanTheSelectedItemQuantity(
 					String input) {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText(input);
 				window.button(JButtonMatcher.withText("Return quantity")).requireDisabled();
@@ -807,7 +810,7 @@ class TotemSwingViewTest {
 			@Test
 			@DisplayName("Button 'return quantity' should delegate to TotemController 'returnProduct'")
 			void testButtonReturnQuantityShouldDelegateToTotemControllerReturnQuantity() {
-				OrderItem itemToReturn = new OrderItem(new Product("Product", 3.0), 5);
+				OrderItem itemToReturn = new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5);
 				GuiActionRunner
 						.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel().addElement(itemToReturn));
 				window.list("cartList").selectItem(0);
@@ -822,8 +825,8 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be disabled when an item is selected, the item quantity changes and the spinner value is equal to or greater than the new item quantity")
 			void testReturnQuantityButtonShouldBeDisabledWhenTheQuantityOfTheSelectedItemChangesAndTheSpinnerValueIsEqualToTheSelectedItemQuantity() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 10);
-				OrderItem modifiedItem = new OrderItem(product, 5);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
 				window.list("cartList").selectItem(0);
@@ -838,8 +841,8 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be enabled when an item is selected, the item quantity changes and the spinner value is less than the new item quantity")
 			void testReturnQuantityButtonShouldBeEnabledWhenTheQuantityOfTheSelectedItemChangesAndTheSpinnerValueIsLessThanTheSelectedItemQuantity() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 10);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
 				window.list("cartList").selectItem(0);
@@ -854,8 +857,8 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should be disabled when an item is selected and the item quantity changes to one")
 			void testReturnQuantityButtonShouldBeDisabledWhenTheQuantityOfTheSelectedItemChangesToOne() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner.execute(() -> listOrderItemsModel.addElement(storedItem));
 				window.list("cartList").selectItem(0);
@@ -870,11 +873,12 @@ class TotemSwingViewTest {
 			@DisplayName("Button 'return quantity' should not change when an item is selected and another item quantity changes")
 			void testReturnQuantityButtonShouldNotChangeWhenAnItemIsSelectedAndAnotherItemChange() {
 				Product product = new Product("Product1", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner.execute(() -> {
-					listOrderItemsModel.addElement(new OrderItem(new Product("Product2", 3.0), 5));
+					listOrderItemsModel
+							.addElement(new OrderItem(new Product("Product2", 3.0), new Order(OrderStatus.OPEN), 5));
 					listOrderItemsModel.addElement(storedItem);
 				});
 				window.list("cartList").selectItem(0);
@@ -888,7 +892,7 @@ class TotemSwingViewTest {
 			@DisplayName("Reset button 'return quantity' should be disabled when the spinner is disabled")
 			void testReturnQuantityButtonShouldBeDisabledWhenTheSpinnerIsDisabled() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText("10");
 				GuiActionRunner.execute(() -> window.spinner("cartReturnSpinner").target().setEnabled(false));
@@ -905,7 +909,7 @@ class TotemSwingViewTest {
 			@DisplayName("Reset the label message when an item is selected")
 			void testResetTheLabelMessageWhenAnItemIsSelected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				GuiActionRunner.execute(() -> window.label("cartMessageLabel").target().setText("foo"));
 				window.list("cartList").selectItem(0);
 				window.label("cartMessageLabel").requireText(" ");
@@ -915,7 +919,7 @@ class TotemSwingViewTest {
 			@DisplayName("Reset the label when an item is deselected")
 			void testResetTheLabelMessageWhenAnItemIsDeselected() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				GuiActionRunner.execute(() -> window.label("cartMessageLabel").target().setText("foo"));
 				window.list("cartList").clearSelection();
@@ -927,7 +931,7 @@ class TotemSwingViewTest {
 			@DisplayName("Show error message when the content of the spinner is not a positive integer or starts with zero")
 			void testShowErrorMessageWhenTheContentOfTheSpinnerIsNotPositiveIntegerOrStartsWithZero(String input) {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText(input);
 				window.label("cartMessageLabel")
@@ -938,7 +942,7 @@ class TotemSwingViewTest {
 			@DisplayName("Reset label message when the spinner is disabled")
 			void testResetLabelMessageWhenTheSpinnerIsDisabled() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText("10");
 				GuiActionRunner.execute(() -> window.spinner("cartReturnSpinner").target().setEnabled(false));
@@ -949,7 +953,7 @@ class TotemSwingViewTest {
 			@DisplayName("Reset label message when an item is selected and the spinner value is less than the selected item quantity")
 			void testResetLabelMessageWhenAnItemIsSelectedAndTheSpinnerValueIsLessThanTheSelectedItemQuantity() {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText("3");
 				window.label("cartMessageLabel").requireText(" ");
@@ -961,7 +965,7 @@ class TotemSwingViewTest {
 			void testShowErrorMessageWhenAnItemIsSelectedAndTheSpinnerValueIsNotLessThanTheSelectedItemQuantity(
 					String input) {
 				GuiActionRunner.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel()
-						.addElement(new OrderItem(new Product("Product", 3.0), 5)));
+						.addElement(new OrderItem(new Product("Product", 3.0), new Order(OrderStatus.OPEN), 5)));
 				window.list("cartList").selectItem(0);
 				window.spinner("cartReturnSpinner").enterText(input);
 				window.label("cartMessageLabel")
@@ -974,8 +978,8 @@ class TotemSwingViewTest {
 			void testShowErrorMessageWhenTheQuantityOfTheSelectedItemChangesAndTheSpinnerValueIsNotLessThanTheSelectedItemQuantity(
 					String input) {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 10);
-				OrderItem modifiedItem = new OrderItem(product, 5);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner
 						.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel().addElement(storedItem));
@@ -991,8 +995,8 @@ class TotemSwingViewTest {
 			@DisplayName("Reset label message when an item is selected, the item quantity changes and the spinner value is less than the new item quantity")
 			void testResetLabelMessageWhenTheQuantityOfTheSelectedItemChangesAndTheSpinnerValueIsLessThanTheSelectedItemQuantity() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 10);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 10);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner
 						.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel().addElement(storedItem));
@@ -1006,8 +1010,8 @@ class TotemSwingViewTest {
 			@DisplayName("Reset label message when an item is selected and the item quantity changes to one")
 			void testResetLabelMessageWhenTheQuantityOfTheSelectedItemChangesToOne() {
 				Product product = new Product("Product", 3.0);
-				OrderItem storedItem = new OrderItem(product, 5);
-				OrderItem modifiedItem = new OrderItem(product, 1);
+				OrderItem storedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 5);
+				OrderItem modifiedItem = new OrderItem(product, new Order(OrderStatus.OPEN), 1);
 				DefaultListModel<OrderItem> listOrderItemsModel = totemSwingView.getCartPane().getListOrderItemsModel();
 				GuiActionRunner
 						.execute(() -> totemSwingView.getCartPane().getListOrderItemsModel().addElement(storedItem));

--- a/raffaelliscandiffio.shop-totem/src/test/resources/META-INF/persistence.xml
+++ b/raffaelliscandiffio.shop-totem/src/test/resources/META-INF/persistence.xml
@@ -10,9 +10,12 @@
 		<mapping-file>/META-INF/Product.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/Stock.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/Order.hbm.xml</mapping-file>	
+		<mapping-file>/META-INF/OrderItem.hbm.xml</mapping-file>
+		
 		<class>com.github.raffaelliscandiffio.model.Product</class>
 		<class>com.github.raffaelliscandiffio.model.Stock</class>
 		<class>com.github.raffaelliscandiffio.model.Order</class>
+		<class>com.github.raffaelliscandiffio.model.OrderItem</class>
 		<exclude-unlisted-classes>true</exclude-unlisted-classes>
 		<properties>
 


### PR DESCRIPTION
### Changelog
 - **Convert OrderItem from Embeddable to Entity**
    - Add auto-generated String id
    - Add OrderItemRepository: save, update, findById, delete
    - Update transaction code and entity manager to use this repository

- **(Mongo) Add reference checks to emulate the behaviour of a JPA entity manager**
    -  OrderRepository - delete: throw an exception and do not delete if the database contains an OrderItem with a reference to the Order
    - OrderRepository - update: throw exception if the object to update does not exist in the database
    - OrderItemRepository - save: throw exception and do not save if the item references to Order or Product are not found in the database
    - OrderItemRepository - update: throw exception if the object to update does not exist in the database