### PR TITLE
Replace Testcontainers with DBs started during Maven build

### DIFF
--- a/.github/workflows/maven_macos.yml
+++ b/.github/workflows/maven_macos.yml
@@ -1,4 +1,4 @@
-name: Java CI with Maven on windows and macos
+name: Java CI with Maven on MacOS
 
 on:
   pull_request:
@@ -9,13 +9,9 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-11
     env:
      workdir: raffaelliscandiffio.shop-totem
-    strategy:
-      matrix:
-        os: [macos-11, windows-2022]
-      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2
@@ -23,6 +19,9 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
+    
+    - name: Install Docker
+      uses: docker-practice/actions-setup-docker@master
         
     - name: Cache Maven packages
       uses: actions/cache@v2

--- a/.github/workflows/maven_windows_macos.yml
+++ b/.github/workflows/maven_windows_macos.yml
@@ -14,7 +14,8 @@ jobs:
      workdir: raffaelliscandiffio.shop-totem
     strategy:
       matrix:
-        os: [macos-11, windows-2019]
+        os: [macos-11, windows-2022]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -26,7 +26,6 @@
 		<logback.classic>1.2.10</logback.classic>
 		<mongo.java.server.version>1.39.0</mongo.java.server.version>
 
-		<testcontainers.version>1.16.3</testcontainers.version>
 		<mysql.version>8.0.28</mysql.version>
 		<hibernate.version>5.4.24.Final</hibernate.version>
 
@@ -97,13 +96,6 @@
 				<scope>import</scope>
 				<type>pom</type>
 			</dependency>
-			<dependency>
-				<groupId>org.testcontainers</groupId>
-				<artifactId>testcontainers-bom</artifactId>
-				<version>${testcontainers.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
 		</dependencies>
 	</dependencyManagement>
 
@@ -156,27 +148,6 @@
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
 			<version>${logback.classic}</version>
-		</dependency>
-
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>testcontainers</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>mysql</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>mongodb</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.testcontainers</groupId>
-			<artifactId>junit-jupiter</artifactId>
-			<scope>test</scope>
 		</dependency>
 
 		<dependency>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -206,26 +206,22 @@
 					</dependencies>
 					<configuration>
 
-						<targetClasses>
-							<param>*repository.mysql.OrderMySqlRepository*</param>
-							<param>*repository.mysql.OrderItemMySqlRepository*</param>
-							<param>*repository.mysql.StockMySqlRepository*</param>
-							<param>*repository.mysql.ProductMySqlRepository*</param>
+						<excludedClasses>
+							<param>${groupId}.model.*</param>
+							<param>${groupId}.view.swing.*</param>
 
-							<param>*repository.mongo.OrderMongoRepository*</param>
-							<param>*repository.mongo.OrderItemMongoRepository*</param>
-							<param>*repository.mongo.StockMongoRepository*</param>
-							<param>*repository.mongo.ProductMongoRepository*</param>
+							<!-- Exclude because there are no UT -->
+							<param>${groupId}.repository.*</param>
+							<param>${groupId}.transaction.*</param>
 
-							<param>*transaction.mysql.TransactionManagerMySql*</param>
-							<param>*transaction.mongo.TransactionManagerMongo*</param>
-						</targetClasses>
+						</excludedClasses>
 						<targetTests>
-							<param>*repository.mysql*</param>
-							<param>*repository.mongo*</param>
-							<param>*transaction.mysql*</param>
-							<param>*transaction.mongo*</param>
+							<!-- Run mutation testing only on unit tests -->
+							<param>${groupId}.*Test</param>
 						</targetTests>
+						<excludedTestClasses>
+							<param>${groupId}.*ViewTest</param>
+						</excludedTestClasses>
 						<mutators>
 							STRONGER
 						</mutators>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -337,7 +337,7 @@
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.27.2</version>
+				<version>0.40.0</version>
 				<configuration>
 					<images>
 						<image>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -176,9 +176,9 @@
 
 	<build>
 		<pluginManagement>
+			<!-- Specify plug-in versions -->
 			<plugins>
 				<plugin>
-					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.22.2</version>
 				</plugin>
@@ -192,43 +192,8 @@
 					<artifactId>maven-site-plugin</artifactId>
 					<version>3.9.1</version>
 				</plugin>
-
-				<plugin>
-					<groupId>org.pitest</groupId>
-					<artifactId>pitest-maven</artifactId>
-					<version>1.7.3</version>
-					<dependencies>
-						<dependency>
-							<groupId>org.pitest</groupId>
-							<artifactId>pitest-junit5-plugin</artifactId>
-							<version>0.14</version>
-						</dependency>
-					</dependencies>
-					<configuration>
-
-						<excludedClasses>
-							<param>${groupId}.model.*</param>
-							<param>${groupId}.view.swing.*</param>
-
-							<!-- Exclude because there are no UT -->
-							<param>${groupId}.repository.*</param>
-							<param>${groupId}.transaction.*</param>
-
-						</excludedClasses>
-						<targetTests>
-							<!-- Run mutation testing only on unit tests -->
-							<param>${groupId}.*Test</param>
-						</targetTests>
-						<excludedTestClasses>
-							<param>${groupId}.*ViewTest</param>
-						</excludedTestClasses>
-						<mutators>
-							STRONGER
-						</mutators>
-						<mutationThreshold>100</mutationThreshold>
-					</configuration>
-				</plugin>
-
+				
+				<!--  Configuring code coverage  -->
 				<plugin>
 					<groupId>org.jacoco</groupId>
 					<artifactId>jacoco-maven-plugin</artifactId>
@@ -252,29 +217,19 @@
 						</execution>
 					</executions>
 				</plugin>
-				<plugin>
-					<groupId>org.sonarsource.scanner.maven</groupId>
-					<artifactId>sonar-maven-plugin</artifactId>
-					<version>3.9.1.2184</version>
-				</plugin>
-				<plugin>
-					<groupId>org.eluder.coveralls</groupId>
-					<artifactId>coveralls-maven-plugin</artifactId>
-					<version>4.3.0</version>
-					<dependencies>
-						<!-- This is required when using JDK 9 or higher since javax.xml.bind 
-							has been removed from the JDK -->
-						<dependency>
-							<groupId>javax.xml.bind</groupId>
-							<artifactId>jaxb-api</artifactId>
-							<version>2.3.1</version>
-						</dependency>
-					</dependencies>
-				</plugin>
+
 			</plugins>
 		</pluginManagement>
 
+
 		<plugins>
+
+			<plugin>
+				<groupId>org.sonarsource.scanner.maven</groupId>
+				<artifactId>sonar-maven-plugin</artifactId>
+				<version>3.9.1.2184</version>
+			</plugin>
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
@@ -282,6 +237,8 @@
 					<skipTests>${skipUTs}</skipTests>
 				</configuration>
 			</plugin>
+
+			<!-- Manually add source folders -->
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
@@ -301,20 +258,82 @@
 					</execution>
 				</executions>
 			</plugin>
+
+
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
 				<version>3.0.0-M5</version>
 				<executions>
 					<execution>
+						<id>Integrations</id>
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+						<configuration>
+							<includes>
+								<include>**/*IT.java</include>
+							</includes>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>
 
+			<!-- Coveralls -->
+			<plugin>
+				<groupId>org.eluder.coveralls</groupId>
+				<artifactId>coveralls-maven-plugin</artifactId>
+				<version>4.3.0</version>
+				<dependencies>
+					<!-- This is required when using JDK 9 or higher since javax.xml.bind 
+						has been removed from the JDK -->
+					<dependency>
+						<groupId>javax.xml.bind</groupId>
+						<artifactId>jaxb-api</artifactId>
+						<version>2.3.1</version>
+					</dependency>
+				</dependencies>
+			</plugin>
+
+			<!-- Mutation testing -->
+			<plugin>
+				<groupId>org.pitest</groupId>
+				<artifactId>pitest-maven</artifactId>
+				<version>1.7.3</version>
+				<dependencies>
+					<dependency>
+						<groupId>org.pitest</groupId>
+						<artifactId>pitest-junit5-plugin</artifactId>
+						<version>0.14</version>
+					</dependency>
+				</dependencies>
+				<configuration>
+
+					<excludedClasses>
+						<param>${groupId}.model.*</param>
+						<param>${groupId}.view.swing.*</param>
+
+						<!-- Exclude because there are no UT -->
+						<param>${groupId}.repository.*</param>
+						<param>${groupId}.transaction.*</param>
+
+					</excludedClasses>
+					<targetTests>
+						<!-- Run mutation testing only on unit tests -->
+						<param>${groupId}.*Test</param>
+					</targetTests>
+					<excludedTestClasses>
+						<param>${groupId}.*ViewTest</param>
+					</excludedTestClasses>
+					<mutators>
+						STRONGER
+					</mutators>
+					<mutationThreshold>100</mutationThreshold>
+				</configuration>
+			</plugin>
+
+			<!-- Start docker containers with databases for Integration Tests -->
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -189,6 +189,11 @@
 			<artifactId>hibernate-core</artifactId>
 			<version>${hibernate.version}</version>
 		</dependency>
+		<dependency>
+			<groupId>org.hibernate</groupId>
+			<artifactId>hibernate-c3p0</artifactId>
+			<version>${hibernate.version}</version>
+		</dependency>
 		<!-- https://mvnrepository.com/artifact/info.picocli/picocli -->
 		<dependency>
 			<groupId>info.picocli</groupId>
@@ -237,7 +242,7 @@
 							<param>*repository.mysql.ProductMySqlRepository*</param>
 
 							<param>*repository.mongo.OrderMongoRepository*</param>
-							<param>*repository.mongo.OrderItemMongoRepository*</param>						
+							<param>*repository.mongo.OrderItemMongoRepository*</param>
 							<param>*repository.mongo.StockMongoRepository*</param>
 							<param>*repository.mongo.ProductMongoRepository*</param>
 
@@ -338,6 +343,48 @@
 						<goals>
 							<goal>integration-test</goal>
 							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+
+			<plugin>
+				<groupId>io.fabric8</groupId>
+				<artifactId>docker-maven-plugin</artifactId>
+				<version>0.27.2</version>
+				<configuration>
+					<images>
+						<image>
+							<name>mysql:8.0.28</name>
+							<run>
+								<wait>
+									<log>mysqld: ready for connections</log>
+									<time>20000</time>
+								</wait>
+								<env>
+									<MYSQL_ALLOW_EMPTY_PASSWORD>1</MYSQL_ALLOW_EMPTY_PASSWORD>
+									<MYSQL_DATABASE>totem</MYSQL_DATABASE>
+								</env>
+								<ports>
+									<port>3306:3306</port>
+								</ports>
+							</run>
+						</image>
+					</images>
+				</configuration>
+				<executions>
+					<execution>
+						<id>docker:start</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>start</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>docker:stop</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>stop</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -345,7 +345,7 @@
 							<run>
 								<wait>
 									<log>mysqld: ready for connections</log>
-									<time>20000</time>
+									<time>60000</time>
 								</wait>
 								<env>
 									<MYSQL_ALLOW_EMPTY_PASSWORD>1</MYSQL_ALLOW_EMPTY_PASSWORD>
@@ -361,7 +361,7 @@
 							<run>
 								<wait>
 									<log>connecting to</log>
-									<time>50000</time>
+									<time>60000</time>
 								</wait>
 								<ports>
 									<port>27017:27017</port>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -341,7 +341,7 @@
 				<configuration>
 					<images>
 						<image>
-							<name>mysql:8.0.29</name>
+							<name>mysql:latest</name>
 							<run>
 								<wait>
 									<log>mysqld: ready for connections</log>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -370,6 +370,20 @@
 								</ports>
 							</run>
 						</image>
+						<image>
+							<name>candis/mongo-replica-set</name>
+							<run>
+								<wait>
+									<log>connecting to</log>
+									<time>50000</time>
+								</wait>
+								<ports>
+									<port>27017:27017</port>
+									<port>27018:27018</port>
+									<port>27019:27019</port>
+								</ports>
+							</run>
+						</image>
 					</images>
 				</configuration>
 				<executions>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -341,7 +341,7 @@
 				<configuration>
 					<images>
 						<image>
-							<name>mysql:latest</name>
+							<name>mysql:8.0.29</name>
 							<run>
 								<wait>
 									<log>mysqld: ready for connections</log>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -341,7 +341,7 @@
 				<configuration>
 					<images>
 						<image>
-							<name>mysql:8.0.28</name>
+							<name>mysql:8.0.29</name>
 							<run>
 								<wait>
 									<log>mysqld: ready for connections</log>

--- a/raffaelliscandiffio.shop-totem/pom.xml
+++ b/raffaelliscandiffio.shop-totem/pom.xml
@@ -311,20 +311,20 @@
 				<configuration>
 
 					<excludedClasses>
-						<param>${groupId}.model.*</param>
-						<param>${groupId}.view.swing.*</param>
+						<param>${project.groupId}.model.*</param>
+						<param>${project.groupId}.view.swing.*</param>
 
 						<!-- Exclude because there are no UT -->
-						<param>${groupId}.repository.*</param>
-						<param>${groupId}.transaction.*</param>
+						<param>${project.groupId}.repository.*</param>
+						<param>${project.groupId}.transaction.*</param>
 
 					</excludedClasses>
 					<targetTests>
 						<!-- Run mutation testing only on unit tests -->
-						<param>${groupId}.*Test</param>
+						<param>${project.groupId}.*Test</param>
 					</targetTests>
 					<excludedTestClasses>
-						<param>${groupId}.*ViewTest</param>
+						<param>${project.groupId}.*ViewTest</param>
 					</excludedTestClasses>
 					<mutators>
 						STRONGER

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryIT.java
@@ -29,7 +29,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 @Testcontainers(disabledWithoutDocker = true)
-class OrderMongoRepositoryTestcontainersIT {
+class OrderMongoRepositoryIT {
 
 	private static final OrderStatus CLOSED = OrderStatus.CLOSED;
 	private static final OrderStatus OPEN = OrderStatus.OPEN;

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepositoryIT.java
@@ -16,19 +16,17 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Order;
 import com.github.raffaelliscandiffio.model.OrderStatus;
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
-@Testcontainers(disabledWithoutDocker = true)
+
+
 class OrderMongoRepositoryIT {
 
 	private static final OrderStatus CLOSED = OrderStatus.CLOSED;
@@ -43,14 +41,16 @@ class OrderMongoRepositoryIT {
 	private MongoCollection<Document> orderCollection;
 	private MongoCollection<Document> itemCollection;
 
-	@Container
-	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");
 
 	@BeforeEach
 	public void setup() {
-		client = new MongoClient(new ServerAddress(mongo.getContainerIpAddress(), mongo.getFirstMappedPort()));
+		String uri = "mongodb://localhost:27017,localhost:27018,localhost:27019/?replicaSet=rs0&readPreference=primary&ssl=false";
+		client = MongoClients.create(uri);
 		MongoDatabase database = client.getDatabase(DATABASE_NAME);
 		database.drop();
+		database.createCollection(ORDER_COLLECTION_NAME);
+		database.createCollection(ORDER_ITEM_COLLECTION_NAME);
+		
 		orderCollection = database.getCollection(ORDER_COLLECTION_NAME);
 		itemCollection = database.getCollection(ORDER_ITEM_COLLECTION_NAME);
 
@@ -263,3 +263,4 @@ class OrderMongoRepositoryIT {
 	}
 
 }
+

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepositoryIT.java
@@ -25,7 +25,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 @Testcontainers(disabledWithoutDocker = true)
-class ProductMongoRepositoryTestcontainersIT {
+class ProductMongoRepositoryIT {
 
 	@Container
 	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepositoryIT.java
@@ -13,22 +13,18 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MongoDBContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Product;
-import com.mongodb.MongoClient;
-import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
+import com.mongodb.client.MongoClients;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
-@Testcontainers(disabledWithoutDocker = true)
+
+
 class ProductMongoRepositoryIT {
 
-	@Container
-	public static final MongoDBContainer mongo = new MongoDBContainer("mongo:5.0.6");
 
 	private MongoClient client;
 	private ClientSession session;
@@ -44,11 +40,14 @@ class ProductMongoRepositoryIT {
 
 	@BeforeEach
 	public void setup() {
-		client = new MongoClient(new ServerAddress(mongo.getContainerIpAddress(), mongo.getFirstMappedPort()));
+		String uri = "mongodb://localhost:27017,localhost:27018,localhost:27019/?replicaSet=rs0&readPreference=primary&ssl=false";
+		client = MongoClients.create(uri);
 		session = client.startSession();
 		productRepository = new ProductMongoRepository(client, session, TOTEM_DB_NAME, PRODUCT_COLLECTION_NAME);
 		MongoDatabase database = client.getDatabase(TOTEM_DB_NAME);
 		database.drop();
+		database.createCollection(PRODUCT_COLLECTION_NAME);
+		
 		productCollection = database.getCollection(PRODUCT_COLLECTION_NAME);
 
 	}
@@ -180,3 +179,4 @@ class ProductMongoRepositoryIT {
 	}
 
 }
+

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepositoryIT.java
@@ -29,7 +29,7 @@ import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
 
 @Testcontainers(disabledWithoutDocker = true)
-class StockMongoRepositoryTestcontainersIT {
+class StockMongoRepositoryIT {
 
 	private static final String DATABASE_NAME = "totem";
 	private static final String PRODUCT_COLLECTION_NAME = "product";

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderItemMySqlRepositoryIT.java
@@ -14,16 +14,13 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Order;
 import com.github.raffaelliscandiffio.model.OrderItem;
 import com.github.raffaelliscandiffio.model.OrderStatus;
 import com.github.raffaelliscandiffio.model.Product;
 
-@Testcontainers(disabledWithoutDocker = true)
+
 class OrderItemMySqlRepositoryIT {
 
 	private static final String DATABASE_NAME = "totem";
@@ -38,13 +35,10 @@ class OrderItemMySqlRepositoryIT {
 	private Order order_1;
 	private Order order_2;
 
-	@Container
-	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
-			.withDatabaseName(DATABASE_NAME).withUsername("mysql").withPassword("mysql");
 
 	@BeforeAll
 	public static void createEntityManagerFactory() {
-		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+		System.setProperty("db.port", "3306");
 		System.setProperty("db.name", DATABASE_NAME);
 		managerFactory = Persistence.createEntityManagerFactory("mysql-test");
 	}

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderMySqlRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/OrderMySqlRepositoryIT.java
@@ -14,14 +14,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Order;
 import com.github.raffaelliscandiffio.model.OrderStatus;
 
-@Testcontainers(disabledWithoutDocker = true)
+
 class OrderMySqlRepositoryIT {
 
 	private static final String DATABASE_NAME = "totem";
@@ -29,13 +26,10 @@ class OrderMySqlRepositoryIT {
 	private EntityManager entityManager;
 	private OrderMySqlRepository orderRepository;
 
-	@Container
-	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
-			.withDatabaseName(DATABASE_NAME).withUsername("mysql").withPassword("mysql");
 
 	@BeforeAll
 	public static void createEntityManagerFactory() {
-		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+		System.setProperty("db.port", "3306");		
 		System.setProperty("db.name", DATABASE_NAME);
 		managerFactory = Persistence.createEntityManagerFactory("mysql-test");
 	}
@@ -136,3 +130,4 @@ class OrderMySqlRepositoryIT {
 	}
 
 }
+

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/ProductMySqlRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/ProductMySqlRepositoryIT.java
@@ -14,13 +14,10 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Product;
 
-@Testcontainers(disabledWithoutDocker = true)
+
 class ProductMySqlRepositoryIT {
 
 	private static final String DATABASE_NAME = "totem";
@@ -31,13 +28,10 @@ class ProductMySqlRepositoryIT {
 	private Product product_1;
 	private Product product_2;
 
-	@Container
-	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
-			.withDatabaseName(DATABASE_NAME).withUsername("mysql").withPassword("mysql");
 
 	@BeforeAll
 	public static void createEntityManagerFactory() {
-		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+		System.setProperty("db.port", "3306");		
 		System.setProperty("db.name", DATABASE_NAME);
 		managerFactory = Persistence.createEntityManagerFactory("mysql-test");
 	}

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/StockMySqlRepositoryIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/repository/mysql/StockMySqlRepositoryIT.java
@@ -14,14 +14,11 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.model.Stock;
 
-@Testcontainers(disabledWithoutDocker = true)
+
 class StockMySqlRepositoryIT {
 
 	private static final int STOCK_QUANTITY = 10;
@@ -35,13 +32,10 @@ class StockMySqlRepositoryIT {
 	private StockMySqlRepository stockRepository;
 	private static final String DATABASE_NAME = "totem";
 
-	@Container
-	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
-			.withDatabaseName(DATABASE_NAME).withUsername("mysql").withPassword("mysql");
 
 	@BeforeAll
 	public static void createEntityManagerFactory() {
-		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+		System.setProperty("db.port", "3306");		
 		System.setProperty("db.name", DATABASE_NAME);
 		managerFactory = Persistence.createEntityManagerFactory("mysql-test");
 	}

--- a/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mysql/TransactionManagerMySqlIT.java
+++ b/raffaelliscandiffio.shop-totem/src/it/java/com/github/raffaelliscandiffio/transaction/mysql/TransactionManagerMySqlIT.java
@@ -13,9 +13,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.junit.jupiter.Container;
-import org.testcontainers.junit.jupiter.Testcontainers;
 
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.repository.mysql.OrderItemMySqlRepository;
@@ -24,7 +21,7 @@ import com.github.raffaelliscandiffio.repository.mysql.ProductMySqlRepository;
 import com.github.raffaelliscandiffio.repository.mysql.StockMySqlRepository;
 import com.github.raffaelliscandiffio.transaction.TransactionException;
 
-@Testcontainers(disabledWithoutDocker = true)
+
 class TransactionManagerMySqlIT {
 
 	private static final String DB_NAME = "totem";
@@ -32,13 +29,10 @@ class TransactionManagerMySqlIT {
 	private EntityManager entityManager;
 	private TransactionManagerMySql transactionManager;
 
-	@Container
-	public static final MySQLContainer<?> mysqlContainer = new MySQLContainer<>("mysql:8.0.28")
-			.withDatabaseName(DB_NAME).withUsername("mysql").withPassword("mysql");
 
 	@BeforeAll
-	static void setupClass() {
-		System.setProperty("db.port", mysqlContainer.getFirstMappedPort().toString());
+	public static void setupClass() {
+		System.setProperty("db.port", "3306");
 		System.setProperty("db.name", DB_NAME);
 		entityManagerFactory = Persistence.createEntityManagerFactory("mysql-test");
 

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderItemMongoRepository.java
@@ -14,7 +14,7 @@ import com.github.raffaelliscandiffio.model.OrderItem;
 import com.github.raffaelliscandiffio.model.OrderStatus;
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.repository.OrderItemRepository;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.result.UpdateResult;

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/OrderMongoRepository.java
@@ -12,7 +12,7 @@ import org.bson.types.ObjectId;
 import com.github.raffaelliscandiffio.model.Order;
 import com.github.raffaelliscandiffio.model.OrderStatus;
 import com.github.raffaelliscandiffio.repository.OrderRepository;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.result.UpdateResult;

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/ProductMongoRepository.java
@@ -9,7 +9,7 @@ import org.bson.types.ObjectId;
 
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.repository.ProductRepository;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.model.Filters;

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepository.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/repository/mongo/StockMongoRepository.java
@@ -12,7 +12,7 @@ import org.bson.types.ObjectId;
 import com.github.raffaelliscandiffio.model.Product;
 import com.github.raffaelliscandiffio.model.Stock;
 import com.github.raffaelliscandiffio.repository.StockRepository;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.result.UpdateResult;

--- a/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
+++ b/raffaelliscandiffio.shop-totem/src/main/java/com/github/raffaelliscandiffio/transaction/mongo/TransactionManagerMongo.java
@@ -7,7 +7,7 @@ import com.github.raffaelliscandiffio.repository.mongo.StockMongoRepository;
 import com.github.raffaelliscandiffio.transaction.TransactionCode;
 import com.github.raffaelliscandiffio.transaction.TransactionException;
 import com.github.raffaelliscandiffio.transaction.TransactionManager;
-import com.mongodb.MongoClient;
+import com.mongodb.client.MongoClient;
 import com.mongodb.client.ClientSession;
 
 public class TransactionManagerMongo implements TransactionManager {

--- a/raffaelliscandiffio.shop-totem/src/test/resources/META-INF/persistence.xml
+++ b/raffaelliscandiffio.shop-totem/src/test/resources/META-INF/persistence.xml
@@ -9,9 +9,9 @@
 		<provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 		<mapping-file>/META-INF/Product.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/Stock.hbm.xml</mapping-file>
-		<mapping-file>/META-INF/Order.hbm.xml</mapping-file>	
+		<mapping-file>/META-INF/Order.hbm.xml</mapping-file>
 		<mapping-file>/META-INF/OrderItem.hbm.xml</mapping-file>
-		
+
 		<class>com.github.raffaelliscandiffio.model.Product</class>
 		<class>com.github.raffaelliscandiffio.model.Stock</class>
 		<class>com.github.raffaelliscandiffio.model.Order</class>
@@ -21,16 +21,18 @@
 
 			<property name="javax.persistence.jdbc.driver"
 				value="com.mysql.cj.jdbc.Driver" />
-			<property name="javax.persistence.jdbc.user" value="mysql" />
-			<property name="javax.persistence.jdbc.password"
-				value="mysql" />
-			<property name="hibernate.show_sql" value="true"/>
+			<property name="javax.persistence.jdbc.user" value="root" />
+			<property name="javax.persistence.jdbc.password" value="" />
+
 			<property name="javax.persistence.jdbc.url"
-				value="jdbc:mysql://localhost:${db.port}/${db.name}" />
+				value="jdbc:mysql://localhost:${db.port}/totem" />
+			<property name="hibernate.dialect"
+				value="org.hibernate.dialect.MySQL8Dialect" />
 
 			<property
 				name="javax.persistence.schema-generation.database.action"
-				value="drop-and-create" />	
+				value="drop-and-create" />
+
 
 		</properties>
 	</persistence-unit>


### PR DESCRIPTION
**This Pull Request changes:**

- IT tests concerning the two databases MongoDB and MySQL. They are no more handled with Testcontainers. We replace it with docker images in containers tied to the maven build (started during pre-integration-test and stopped with post-integration-test). We decided to drop the implementation with Testcontainers in preparation for E2E testing with BDD.
    - For MySQL we use the default docker image
    - For MongoDB we use the image `candis/mongo-replica-set` that handles the configuration of a replica-set, needed to use transactions. 
- Mongo IT tests fixing problems with multi documents transactions.

If we want to start the docker images for production purposes, we can do that with the following commands:
- MongoDB:
```
docker run -d -p 27017:27017 -p 27018:27018 -p 27019:27019 candis/mongo-replica-set
```
- MySQL: 

```
docker run -d -p 3306:3306 -e MYSQL_DATABASE="totem" -e MYSQL_ROOT_PASSWORD="" -e MYSQL_ALLOW_EMPTY_PASSWORD="yes" mysql:8.0.28
```